### PR TITLE
StyleCop fixes including code layout restructure

### DIFF
--- a/azure-proto-core/Adapters/ModelAdapters.cs
+++ b/azure-proto-core/Adapters/ModelAdapters.cs
@@ -1,14 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// TODO: GENERATOR Remove this class after generation updates
+    ///     TODO: GENERATOR Remove this class after generation updates
     /// </summary>
     /// <typeparam name="T">The type of the underlying model this class wraps</typeparam>
-    public abstract class TrackedResource<T> : TrackedResource where T : class
+    public abstract class TrackedResource<T> : TrackedResource
+        where T : class
     {
         protected TrackedResource(ResourceIdentifier id, Location location, T data)
         {
@@ -26,18 +26,20 @@ namespace azure_proto_core
     }
 
     //Or call generic resource, other resource??
-    public abstract class ProxyResource<T> : Resource where T : class
+    public abstract class ProxyResource<T> : Resource
+        where T : class
     {
-        public override ResourceIdentifier Id { get; protected set; }
-        protected ProxyResource (ResourceIdentifier id, T data)
+        protected ProxyResource(ResourceIdentifier id, T data)
         {
             Id = id;
             Model = data;
         }
 
+        public override ResourceIdentifier Id { get; protected set; }
+
         public virtual T Model { get; set; }
 
-        public static implicit operator T(ProxyResource <T> other)
+        public static implicit operator T(ProxyResource<T> other)
         {
             return other.Model;
         }

--- a/azure-proto-core/Adapters/PhResponse.cs
+++ b/azure-proto-core/Adapters/PhResponse.cs
@@ -1,17 +1,23 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
+using Azure;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Placeholder class, used to convert the gewneric type argument for a response from the underlyign rest API to the desired type argument in the response
+    ///     Placeholder class, used to convert the gewneric type argument for a response from the underlyign rest API to the
+    ///     desired type argument in the response
     /// </summary>
     /// <typeparam name="T">The desired type argument for the returned response</typeparam>
     /// <typeparam name="U">The type argument of the response to be converted</typeparam>
-    public class PhArmResponse<T, U> : ArmResponse<T> where T: class where U : class
+    public class PhArmResponse<T, U> : ArmResponse<T>
+        where T : class
+        where U : class
     {
-        Response<U> _wrapped;
-        Func<U, T> _converter;
+        private readonly Func<U, T> _converter;
+        private readonly Response<U> _wrapped;
 
         public PhArmResponse(Response<U> wrapped, Func<U, T> converter)
         {

--- a/azure-proto-core/Adapters/PhWrappingAsyncPageable.cs
+++ b/azure-proto-core/Adapters/PhWrappingAsyncPageable.cs
@@ -1,24 +1,32 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
+using Azure;
 
 namespace azure_proto_core.Adapters
 {
     /// <summary>
-    /// Returns an AsyncPageable that executes a given task before retrieving the first page of results
+    ///     Returns an AsyncPageable that executes a given task before retrieving the first page of results
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class PhTaskDeferringAsyncPageable<T> : AsyncPageable<T> where T : notnull
+    public class PhTaskDeferringAsyncPageable<T> : AsyncPageable<T>
+        where T : notnull
     {
-        Func<Task<AsyncPageable<T>>> _task;
+        private readonly Func<Task<AsyncPageable<T>>> _task;
+
         public PhTaskDeferringAsyncPageable(Func<Task<AsyncPageable<T>>> task)
         {
             _task = task;
         }
-        public async override IAsyncEnumerable<Page<T>> AsPages(string continuationToken = null, int? pageSizeHint = null)
+
+        public override async IAsyncEnumerable<Page<T>> AsPages(
+            string continuationToken = null,
+            int? pageSizeHint = null)
         {
             await foreach (var page in (await _task()).AsPages())
             {
@@ -28,15 +36,18 @@ namespace azure_proto_core.Adapters
     }
 
     /// <summary>
-    /// This class allows performing conversions on pages of data as they are accessed - used in the prototype to convett between underlying model types and the new model types that extend Resource, 
-    /// and also for returning Operations classes for those underlying objects.
+    ///     This class allows performing conversions on pages of data as they are accessed - used in the prototype to convett
+    ///     between underlying model types and the new model types that extend Resource,
+    ///     and also for returning Operations classes for those underlying objects.
     /// </summary>
     /// <typeparam name="T">The type parameter of the Pageable we are wrapping</typeparam>
     /// <typeparam name="U">The desired type parameter of the returned pageable</typeparam>
-    public class PhWrappingPageable<T, U> : Pageable<U> where U : class where T : class
+    public class PhWrappingPageable<T, U> : Pageable<U>
+        where U : class
+        where T : class
     {
-        IEnumerable<Pageable<T>> _wrapped;
-        Func<T, U> _converter;
+        private readonly Func<T, U> _converter;
+        private readonly IEnumerable<Pageable<T>> _wrapped;
 
         public PhWrappingPageable(Pageable<T> wrapped, Func<T, U> converter)
         {
@@ -49,6 +60,7 @@ namespace azure_proto_core.Adapters
             _wrapped = wrapped;
             _converter = converter;
         }
+
         public override IEnumerable<Page<U>> AsPages(string continuationToken = null, int? pageSizeHint = null)
         {
             foreach (var pages in _wrapped)
@@ -62,14 +74,18 @@ namespace azure_proto_core.Adapters
     }
 
     /// <summary>
-    /// As above, returns an AsyncPageable that transforms each page of contents  after they are retrieved from the server accorgin to the profived transformation function
+    ///     As above, returns an AsyncPageable that transforms each page of contents  after they are retrieved from the server
+    ///     accorgin to the profived transformation function
     /// </summary>
     /// <typeparam name="T">The generic type parameter of the underlying wrapped AsyncPageable</typeparam>
     /// <typeparam name="U">The desired generic type parameter fo the returned AsyncPageable</typeparam>
-    public class PhWrappingAsyncPageable<T, U> : AsyncPageable<U> where U: class where T: class
+    public class PhWrappingAsyncPageable<T, U> : AsyncPageable<U>
+        where U : class
+        where T : class
     {
-        IEnumerable<AsyncPageable<T>> _wrapped;
-        Func<T, U> _converter;
+        private readonly Func<T, U> _converter;
+        private readonly IEnumerable<AsyncPageable<T>> _wrapped;
+
         public PhWrappingAsyncPageable(AsyncPageable<T> wrapped, Func<T, U> converter)
         {
             _wrapped = new[] { wrapped };
@@ -82,7 +98,9 @@ namespace azure_proto_core.Adapters
             _converter = converter;
         }
 
-        public async override IAsyncEnumerable<Page<U>> AsPages( string continuationToken = null, int? pageSizeHint = null)
+        public override async IAsyncEnumerable<Page<U>> AsPages(
+            string continuationToken = null,
+            int? pageSizeHint = null)
         {
             foreach (var pageEnum in _wrapped)
             {
@@ -94,10 +112,12 @@ namespace azure_proto_core.Adapters
         }
     }
 
-    internal class WrappingPage<T, U> : Page<U> where U : class where T : class
+    internal class WrappingPage<T, U> : Page<U>
+        where U : class
+        where T : class
     {
-        Page<T> _wrapped;
-        Func<T, U> _converter;
+        private readonly Func<T, U> _converter;
+        private readonly Page<T> _wrapped;
 
         internal WrappingPage(Page<T> wrapped, Func<T, U> converter)
         {

--- a/azure-proto-core/ApiVersionsBase.cs
+++ b/azure-proto-core/ApiVersionsBase.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Text.RegularExpressions;
 
 namespace azure_proto_core
@@ -17,21 +20,84 @@ namespace azure_proto_core
             return version._value;
         }
 
+        public int CompareTo(string other)
+        {
+            if (other == null)
+            {
+                return 1;
+            }
+
+            var regPattern = @"(\d\d\d\d-\d\d-\d\d)(.*)";
+
+            var otherMatch = Regex.Match(other, regPattern);
+            var thisMatch = Regex.Match(_value, regPattern);
+
+            var otherDatePart = otherMatch.Groups[1].Value;
+            var thisDatePart = thisMatch.Groups[1].Value;
+
+            if (otherDatePart == thisDatePart)
+            {
+                var otherPreviewPart = otherMatch.Groups[2].Value;
+                var thisPreviewPart = thisMatch.Groups[2].Value;
+
+                if (otherPreviewPart == thisPreviewPart)
+                {
+                    return 0;
+                }
+
+                if (string.IsNullOrEmpty(otherPreviewPart))
+                {
+                    return -1;
+                }
+
+                if (string.IsNullOrEmpty(thisPreviewPart))
+                {
+                    return 1;
+                }
+
+                return thisPreviewPart.CompareTo(otherPreviewPart);
+            }
+
+            return thisDatePart.CompareTo(otherDatePart);
+        }
+
+        public bool Equals(string other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            return other == _value;
+        }
+
         public static bool operator ==(ApiVersionsBase first, string second)
         {
             if (ReferenceEquals(null, first))
+            {
                 return ReferenceEquals(null, second);
+            }
+
             if (ReferenceEquals(null, second))
+            {
                 return false;
+            }
+
             return first.Equals(second);
         }
 
         public static bool operator !=(ApiVersionsBase first, string second)
         {
             if (ReferenceEquals(null, first))
+            {
                 return !ReferenceEquals(null, second);
+            }
+
             if (ReferenceEquals(null, second))
+            {
                 return true;
+            }
+
             return !first.Equals(second);
         }
 
@@ -43,9 +109,14 @@ namespace azure_proto_core
         public override bool Equals(object obj)
         {
             if (obj is ApiVersionsBase)
+            {
                 return Equals(obj as ApiVersionsBase);
+            }
+
             if (obj is string)
+            {
                 return Equals(obj as string);
+            }
 
             return false;
         }
@@ -53,47 +124,6 @@ namespace azure_proto_core
         public override int GetHashCode()
         {
             return _value.GetHashCode();
-        }
-
-        public bool Equals(string other)
-        {
-            if (other == null)
-                return false;
-            return other == _value;
-        }
-
-        public int CompareTo(string other)
-        {
-            if (other == null)
-                return 1;
-
-            string regPattern = @"(\d\d\d\d-\d\d-\d\d)(.*)";
-
-            Match otherMatch = Regex.Match(other, regPattern);
-            Match thisMatch = Regex.Match(_value, regPattern);
-
-            string otherDatePart = otherMatch.Groups[1].Value;
-            string thisDatePart = thisMatch.Groups[1].Value;
-
-            if (otherDatePart == thisDatePart)
-            {
-                string otherPreviewPart = otherMatch.Groups[2].Value;
-                string thisPreviewPart = thisMatch.Groups[2].Value;
-                if (otherPreviewPart == thisPreviewPart)
-                    return 0;
-
-                if (String.IsNullOrEmpty(otherPreviewPart))
-                    return -1;
-
-                if (String.IsNullOrEmpty(thisPreviewPart))
-                    return 1;
-
-                return thisPreviewPart.CompareTo(otherPreviewPart);
-            }
-            else
-            {
-                return thisDatePart.CompareTo(otherDatePart);
-            }
         }
     }
 }

--- a/azure-proto-core/ArmBuilder.cs
+++ b/azure-proto-core/ArmBuilder.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,6 +20,16 @@ namespace azure_proto_core
             _unTypedContainerOperations = containerOperations;
         }
 
+        public TResource Build()
+        {
+            ThrowIfNotValid();
+            OnBeforeBuild();
+            _Build();
+            OnAfterBuild();
+
+            return _resource;
+        }
+
         public ArmResponse<TOperations> Create(string name, CancellationToken cancellationToken = default)
         {
             _resource = Build();
@@ -24,7 +37,9 @@ namespace azure_proto_core
             return _unTypedContainerOperations.Create(name, _resource, cancellationToken);
         }
 
-        public async Task<ArmResponse<TOperations>> CreateAsync(string name, CancellationToken cancellationToken = default)
+        public async Task<ArmResponse<TOperations>> CreateAsync(
+            string name,
+            CancellationToken cancellationToken = default)
         {
             _resource = Build();
 
@@ -38,46 +53,42 @@ namespace azure_proto_core
             return _unTypedContainerOperations.StartCreate(name, _resource, cancellationToken);
         }
 
-        public async Task<ArmOperation<TOperations>> StartCreateAsync(string name, CancellationToken cancellationToken = default)
+        public async Task<ArmOperation<TOperations>> StartCreateAsync(
+            string name,
+            CancellationToken cancellationToken = default)
         {
             _resource = Build();
 
             return await _unTypedContainerOperations.StartCreateAsync(name, _resource, cancellationToken);
         }
 
-        private void ThrowIfNotValid()
-        {
-            string message;
-            if (!IsValid(out message))
-                throw new InvalidOperationException(message);
-        }
-
         protected virtual bool IsValid(out string message)
         {
-            message = String.Empty;
-            return true;
-        }
+            message = string.Empty;
 
-        protected virtual void OnBeforeBuild()
-        {
+            return true;
         }
 
         protected virtual void OnAfterBuild()
         {
         }
 
-        private void _Build()
+        protected virtual void OnBeforeBuild()
         {
-
         }
 
-        public TResource Build()
+        private void _Build()
         {
-            ThrowIfNotValid();
-            OnBeforeBuild();
-            _Build();
-            OnAfterBuild();
-            return _resource;
+        }
+
+        private void ThrowIfNotValid()
+        {
+            string message;
+
+            if (!IsValid(out message))
+            {
+                throw new InvalidOperationException(message);
+            }
         }
     }
 }

--- a/azure-proto-core/ArmClient.cs
+++ b/azure-proto-core/ArmClient.cs
@@ -1,110 +1,161 @@
-﻿using Azure;
-using Azure.Core;
-using Azure.Identity;
-using Azure.ResourceManager.Resources;
-using Azure.ResourceManager.Resources.Models;
-using azure_proto_core.Adapters;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
+using Azure.Core;
+using Azure.Identity;
+using Azure.ResourceManager.Resources;
+using Azure.ResourceManager.Resources.Models;
+using azure_proto_core.Adapters;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// The entry point for all ARM clients.  Note that, we may not want to take a dirrect dependency on Azure.Identity, so we may make the
-    /// credential required.
-    /// TODO: What is appropriate naming for ArmClient , given that we would not liek to make distinctions between data and management.
+    ///     The entry point for all ARM clients.  Note that, we may not want to take a dirrect dependency on Azure.Identity, so
+    ///     we may make the
+    ///     credential required.
+    ///     TODO: What is appropriate naming for ArmClient , given that we would not liek to make distinctions between data and
+    ///     management.
     /// </summary>
     public class ArmClient
     {
         internal static readonly string DefaultUri = "https://management.azure.com";
 
-        public Dictionary<string, string> ApiVersionOverrides { get; private set; }
+        public ArmClient()
+            : this(new Uri(DefaultUri), new DefaultAzureCredential(), null, new ArmClientOptions())
+        {
+        }
 
-        public ArmClient() : this(new Uri(DefaultUri), new DefaultAzureCredential(), null, new ArmClientOptions()) { }
+        public ArmClient(string defaultSubscriptionId)
+            : this(new Uri(DefaultUri), new DefaultAzureCredential(), defaultSubscriptionId, new ArmClientOptions())
+        {
+        }
 
-        public ArmClient(string defaultSubscriptionId) : this(new Uri(DefaultUri), new DefaultAzureCredential(), defaultSubscriptionId, new ArmClientOptions()) { }
+        public ArmClient(TokenCredential credential, string defaultSubscriptionId)
+            : this(new Uri(DefaultUri), credential, defaultSubscriptionId, new ArmClientOptions())
+        {
+        }
 
-        public ArmClient(TokenCredential credential, string defaultSubscriptionId) : this(new Uri(DefaultUri), credential, defaultSubscriptionId, new ArmClientOptions()) { }
+        public ArmClient(Uri baseUri, TokenCredential credential)
+            : this(baseUri, credential, null, new ArmClientOptions())
+        {
+        }
 
-        public ArmClient(Uri baseUri, TokenCredential credential) : this(baseUri, credential, null, new ArmClientOptions()) { }
-
-        public ArmClientOptions ClientOptions { get; private set; }
-
-        public ArmClient(Uri baseUri, TokenCredential credential, string defaultSubscriptionId, ArmClientOptions options)
+        public ArmClient(
+            Uri baseUri,
+            TokenCredential credential,
+            string defaultSubscriptionId,
+            ArmClientOptions options)
         {
             ClientContext = new ArmClientContext(baseUri, credential);
             defaultSubscriptionId ??= GetDefaultSubscription().ConfigureAwait(false).GetAwaiter().GetResult();
-            DefaultSubscription = new SubscriptionOperations(ClientContext, new ResourceIdentifier($"/subscriptions/{defaultSubscriptionId}"));
+            DefaultSubscription = new SubscriptionOperations(
+                ClientContext,
+                new ResourceIdentifier($"/subscriptions/{defaultSubscriptionId}"));
             ApiVersionOverrides = new Dictionary<string, string>();
             ClientOptions = options;
         }
 
-        public SubscriptionOperations DefaultSubscription { get; private set; }
+        public Dictionary<string, string> ApiVersionOverrides { get; }
+
+        public ArmClientOptions ClientOptions { get; }
+
+        public SubscriptionOperations DefaultSubscription { get; }
 
         internal virtual ArmClientContext ClientContext { get; }
 
-        public SubscriptionOperations Subscription(PhSubscriptionModel subscription) => new SubscriptionOperations(this.ClientContext, subscription);
+        internal SubscriptionsOperations SubscriptionsClient =>
+            GetResourcesClient(Guid.NewGuid().ToString()).Subscriptions;
+
+        public SubscriptionOperations Subscription(PhSubscriptionModel subscription)
+        {
+            return new SubscriptionOperations(ClientContext, subscription);
+        }
 
         /// <summary>
         /// </summary>
         /// <param name="subscription"></param>
         /// <returns></returns>
-        public SubscriptionOperations Subscription(ResourceIdentifier subscription) => new SubscriptionOperations(this.ClientContext, subscription);
+        public SubscriptionOperations Subscription(ResourceIdentifier subscription)
+        {
+            return new SubscriptionOperations(ClientContext, subscription);
+        }
 
-        public SubscriptionOperations Subscription(string subscription) => new SubscriptionOperations(this.ClientContext, subscription);
+        public SubscriptionOperations Subscription(string subscription)
+        {
+            return new SubscriptionOperations(ClientContext, subscription);
+        }
 
         public AsyncPageable<SubscriptionOperations> ListSubscriptionsAsync(CancellationToken token = default)
         {
-            return new PhWrappingAsyncPageable<Subscription, SubscriptionOperations>(SubscriptionsClient.ListAsync(token), s => new SubscriptionOperations(this.ClientContext, new PhSubscriptionModel(s)));
+            return new PhWrappingAsyncPageable<Subscription, SubscriptionOperations>(
+                SubscriptionsClient.ListAsync(token),
+                s => new SubscriptionOperations(ClientContext, new PhSubscriptionModel(s)));
         }
 
         public Pageable<SubscriptionOperations> ListSubscriptions(CancellationToken token = default)
         {
-            return new PhWrappingPageable<Subscription, SubscriptionOperations>(SubscriptionsClient.List(token), s => new SubscriptionOperations(this.ClientContext, new PhSubscriptionModel(s)));
+            return new PhWrappingPageable<Subscription, SubscriptionOperations>(
+                SubscriptionsClient.List(token),
+                s => new SubscriptionOperations(ClientContext, new PhSubscriptionModel(s)));
         }
 
-        public AsyncPageable<PhLocation> ListLocationsAsync(string subscriptionId = null, CancellationToken token = default(CancellationToken))
+        public AsyncPageable<PhLocation> ListLocationsAsync(
+            string subscriptionId = null,
+            CancellationToken token = default)
         {
             async Task<AsyncPageable<PhLocation>> PageableFunc()
             {
                 if (string.IsNullOrWhiteSpace(subscriptionId))
                 {
-                    subscriptionId = (await GetDefaultSubscription(token));
+                    subscriptionId = await GetDefaultSubscription(token);
+
                     if (subscriptionId == null)
                     {
                         throw new InvalidOperationException("Please select a default subscription");
                     }
                 }
 
-                return new PhWrappingAsyncPageable<Azure.ResourceManager.Resources.Models.Location, PhLocation>(SubscriptionsClient.ListLocationsAsync(subscriptionId, token), s => new PhLocation(s));
-
+                return new PhWrappingAsyncPageable<Azure.ResourceManager.Resources.Models.Location, PhLocation>(
+                    SubscriptionsClient.ListLocationsAsync(subscriptionId, token),
+                    s => new PhLocation(s));
             }
 
             return new PhTaskDeferringAsyncPageable<PhLocation>(PageableFunc);
-
         }
 
-        public Pageable<PhLocation> ListLocations(string subscriptionId = null, CancellationToken cancellationToken = default(CancellationToken))
+        public Pageable<PhLocation> ListLocations(
+            string subscriptionId = null,
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(subscriptionId))
             {
-                subscriptionId = GetDefaultSubscription(cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+                subscriptionId = GetDefaultSubscription(cancellationToken).ConfigureAwait(false).GetAwaiter()
+                    .GetResult();
+
                 if (subscriptionId == null)
                 {
                     throw new InvalidOperationException("Please select a default subscription");
                 }
             }
 
-            return new PhWrappingPageable<Azure.ResourceManager.Resources.Models.Location, PhLocation>(SubscriptionsClient.ListLocations(subscriptionId, cancellationToken), s => new PhLocation(s));
+            return new PhWrappingPageable<Azure.ResourceManager.Resources.Models.Location, PhLocation>(
+                SubscriptionsClient.ListLocations(subscriptionId, cancellationToken),
+                s => new PhLocation(s));
         }
 
-        public async IAsyncEnumerable<azure_proto_core.Location> ListAvailableLocationsAsync(ResourceType resourceType, [EnumeratorCancellation] CancellationToken cancellationToken = default(CancellationToken))
+        public async IAsyncEnumerable<Location> ListAvailableLocationsAsync(
+            ResourceType resourceType,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            var subscriptionId = (await GetDefaultSubscription(cancellationToken));
+            var subscriptionId = await GetDefaultSubscription(cancellationToken);
+
             if (subscriptionId == null)
             {
                 throw new InvalidOperationException("Please select a default subscription");
@@ -116,87 +167,123 @@ namespace azure_proto_core
             }
         }
 
-        public async IAsyncEnumerable<azure_proto_core.Location> ListAvailableLocationsAsync(string subscription, ResourceType resourceType, [EnumeratorCancellation] CancellationToken cancellationToken = default(CancellationToken))
+        public async IAsyncEnumerable<Location> ListAvailableLocationsAsync(
+            string subscription,
+            ResourceType resourceType,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
-            await foreach (var provider in GetResourcesClient(subscription).Providers.ListAsync(expand: "metadata", cancellationToken: cancellationToken).WithCancellation(cancellationToken))
+            await foreach (var provider in GetResourcesClient(subscription).Providers
+                .ListAsync(expand: "metadata", cancellationToken: cancellationToken)
+                .WithCancellation(cancellationToken))
             {
-                if (string.Equals(provider.Namespace, resourceType?.Namespace, StringComparison.InvariantCultureIgnoreCase))
+                if (string.Equals(
+                    provider.Namespace,
+                    resourceType?.Namespace,
+                    StringComparison.InvariantCultureIgnoreCase))
                 {
                     var foundResource = provider.ResourceTypes.FirstOrDefault(p => resourceType.Equals(p.ResourceType));
+
                     foreach (var location in foundResource.Locations)
                     {
-                        yield return new azure_proto_core.Location(location);
+                        yield return new Location(location);
                     }
                 }
             }
         }
 
-        public IEnumerable<azure_proto_core.Location> ListAvailableLocations(ResourceType resourceType, CancellationToken cancellationToken = default(CancellationToken))
+        public IEnumerable<Location> ListAvailableLocations(
+            ResourceType resourceType,
+            CancellationToken cancellationToken = default)
         {
             var subscription = GetDefaultSubscription().ConfigureAwait(false).GetAwaiter().GetResult();
+
             return ListAvailableLocations(subscription, resourceType, cancellationToken);
         }
 
-        public IEnumerable<azure_proto_core.Location> ListAvailableLocations(string subscription, ResourceType resourceType, CancellationToken cancellationToken = default(CancellationToken))
+        public IEnumerable<Location> ListAvailableLocations(
+            string subscription,
+            ResourceType resourceType,
+            CancellationToken cancellationToken = default)
         {
-            return GetResourcesClient(subscription).Providers.List(expand: "metadata", cancellationToken: cancellationToken)
-                .FirstOrDefault(p => string.Equals(p.Namespace, resourceType?.Namespace, StringComparison.InvariantCultureIgnoreCase))
+            return GetResourcesClient(subscription).Providers
+                .List(expand: "metadata", cancellationToken: cancellationToken)
+                .FirstOrDefault(
+                    p =>
+                        string.Equals(
+                            p.Namespace,
+                            resourceType?.Namespace,
+                            StringComparison.InvariantCultureIgnoreCase))
                 .ResourceTypes.FirstOrDefault(r => resourceType.Equals(r.ResourceType))
-                .Locations.Select(l => new azure_proto_core.Location(l));
+                .Locations.Select(l => new Location(l));
         }
 
         public ResourceGroupOperations ResourceGroup(string subscription, string resourceGroup)
         {
-            return new ResourceGroupOperations(this.ClientContext, $"/subscriptions/{subscription}/resourceGroups/{resourceGroup}");
+            return new ResourceGroupOperations(
+                ClientContext,
+                $"/subscriptions/{subscription}/resourceGroups/{resourceGroup}");
         }
 
         public ResourceGroupOperations ResourceGroup(ResourceIdentifier resourceGroup)
         {
-            return new ResourceGroupOperations(this.ClientContext, resourceGroup);
+            return new ResourceGroupOperations(ClientContext, resourceGroup);
         }
+
         public ResourceGroupOperations ResourceGroup(PhResourceGroup resourceGroup)
         {
-            return new ResourceGroupOperations(this.ClientContext, resourceGroup.Id);
+            return new ResourceGroupOperations(ClientContext, resourceGroup.Id);
         }
 
-        public T GetResourceOperationsBase<T>(TrackedResource resource) where T : TrackedResource
+        public T GetResourceOperationsBase<T>(TrackedResource resource)
+            where T : TrackedResource
         {
             return Activator.CreateInstance(typeof(T), ClientContext, resource) as T;
         }
 
-        public T GetResourceOperationsBase<T>(ResourceIdentifier resource) where T : OperationsBase
+        public T GetResourceOperationsBase<T>(ResourceIdentifier resource)
+            where T : OperationsBase
         {
             return Activator.CreateInstance(typeof(T), ClientContext, resource) as T;
         }
 
-        public T GetResourceOperationsBase<T>(string subscription, string resourceGroup, string name) where T : OperationsBase
+        public T GetResourceOperationsBase<T>(string subscription, string resourceGroup, string name)
+            where T : OperationsBase
         {
             return null;
         }
 
-        public ArmResponse<TOperations> CreateResource<TContainer, TOperations, TResource>(string subscription, string resourceGroup, string name, TResource model, azure_proto_core.Location location = default)
+        public ArmResponse<TOperations> CreateResource<TContainer, TOperations, TResource>(
+            string subscription,
+            string resourceGroup,
+            string name,
+            TResource model,
+            Location location = default)
             where TResource : TrackedResource
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TContainer : ResourceContainerOperations<TOperations, TResource>
         {
             if (location == null)
             {
-                location = azure_proto_core.Location.Default;
+                location = Location.Default;
             }
 
-            TContainer container = Activator.CreateInstance(typeof(TContainer), ClientContext, new ArmResource($"/subscriptions/{subscription}/resourceGroups/{resourceGroup}", location)) as TContainer;
+            var container = Activator.CreateInstance(
+                    typeof(TContainer),
+                    ClientContext,
+                    new ArmResource($"/subscriptions/{subscription}/resourceGroups/{resourceGroup}", location)) as
+                TContainer;
 
             return container.Create(name, model);
         }
 
         /// <summary>
-        /// Fill in the default subscription in the simple case (passed in, or only one subscription available)
+        ///     Fill in the default subscription in the simple case (passed in, or only one subscription available)
         /// </summary>
         /// <param name="token"></param>
         /// <returns></returns>
-        internal async Task<string> GetDefaultSubscription(CancellationToken token = default(CancellationToken))
+        internal async Task<string> GetDefaultSubscription(CancellationToken token = default)
         {
-            string sub = DefaultSubscription?.Id?.Subscription;
+            var sub = DefaultSubscription?.Id?.Subscription;
             if (null == sub)
             {
                 var subs = ListSubscriptionsAsync(token).GetAsyncEnumerator();
@@ -208,11 +295,15 @@ namespace azure_proto_core
                     }
                 }
             }
+
             return sub;
         }
 
-        internal SubscriptionsOperations SubscriptionsClient => GetResourcesClient(Guid.NewGuid().ToString()).Subscriptions;
-
-        internal ResourcesManagementClient GetResourcesClient(string subscription) => ClientContext.GetClient((uri, credential) => new ResourcesManagementClient(uri, subscription, credential));
+        internal ResourcesManagementClient GetResourcesClient(string subscription)
+        {
+            return ClientContext.GetClient(
+                (uri, credential) =>
+                    new ResourcesManagementClient(uri, subscription, credential));
+        }
     }
 }

--- a/azure-proto-core/ArmClientContext.cs
+++ b/azure-proto-core/ArmClientContext.cs
@@ -1,10 +1,14 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
+using Azure.Core;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Base class tracking context information for clients - when we have changed client constructors, this should not be necessary
+    ///     Base class tracking context information for clients - when we have changed client constructors, this should not be
+    ///     necessary
     /// </summary>
     public class ArmClientContext
     {
@@ -14,7 +18,8 @@ namespace azure_proto_core
             Credential = credential;
         }
 
-        public ArmClientContext(ArmClientContext other) : this(other.BaseUri, other.Credential)
+        public ArmClientContext(ArmClientContext other)
+            : this(other.BaseUri, other.Credential)
         {
         }
 
@@ -33,7 +38,8 @@ namespace azure_proto_core
         internal Uri BaseUri { get; }
 
         /// <summary>
-        /// Note that this is currently adapting to underlying management clients - once generator changes are in, this would likely be unnecessary
+        ///     Note that this is currently adapting to underlying management clients - once generator changes are in, this would
+        ///     likely be unnecessary
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="creator"></param>

--- a/azure-proto-core/ArmClientOptions.cs
+++ b/azure-proto-core/ArmClientOptions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -6,14 +9,14 @@ namespace azure_proto_core
 {
     public class ArmClientOptions
     {
-        private Dictionary<Type, object> _overrides = new Dictionary<Type, object>();
         private static readonly object _overridesLock = new object();
+        private readonly Dictionary<Type, object> _overrides = new Dictionary<Type, object>();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public object GetOverrideObject<T>(Func<object> ctor)
         {
             object overrideObject;
-            Type type = typeof(T);
+            var type = typeof(T);
             if (!_overrides.TryGetValue(type, out overrideObject))
             {
                 lock (_overridesLock)
@@ -25,6 +28,7 @@ namespace azure_proto_core
                     }
                 }
             }
+
             return overrideObject;
         }
     }

--- a/azure-proto-core/ArmOperation.cs
+++ b/azure-proto-core/ArmOperation.cs
@@ -1,14 +1,19 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Abstract class for long-running or synchronous applications. If we want to add ARM-specific OM, this is where we would add it.
-    /// We may need to add ARM-specific OM, as customers have asked for additional configurability over polling stratgies on a per-operation basis
-    /// TODO: GENERATOR Remove protected properties, as this should be integrated into the generated client
+    ///     Abstract class for long-running or synchronous applications. If we want to add ARM-specific OM, this is where we
+    ///     would add it.
+    ///     We may need to add ARM-specific OM, as customers have asked for additional configurability over polling stratgies
+    ///     on a per-operation basis
+    ///     TODO: GENERATOR Remove protected properties, as this should be integrated into the generated client
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public abstract class ArmOperation<TOperations> : Operation<TOperations>
@@ -25,35 +30,24 @@ namespace azure_proto_core
     }
 
     /// <summary>
-    /// Generic ARM long runnign operation class for operatiosn with no returned value
-    /// TODO: Reimplement without wrapping
+    ///     Generic ARM long runnign operation class for operatiosn with no returned value
+    ///     TODO: Reimplement without wrapping
     /// </summary>
     public class ArmVoidOperation : ArmOperation<Response>
     {
-        internal class WrappingResponse : ArmResponse<Response>
-        {
-            Response _wrapped;
+        private readonly Operation<Response> _wrapped;
 
-            public WrappingResponse(Response wrapped)
-            {
-                _wrapped = wrapped;
-            }
-
-            public override Response Value => _wrapped;
-
-            public override Response GetRawResponse() => _wrapped;
-        }
-
-        Operation<Response> _wrapped;
-        public ArmVoidOperation(Operation<Response> other) : base(null)
+        public ArmVoidOperation(Operation<Response> other)
+            : base(null)
         {
             _wrapped = other;
         }
 
-        public ArmVoidOperation(Response other) : base(other)
+        public ArmVoidOperation(Response other)
+            : base(other)
         {
-        }        
-        
+        }
+
         public override string Id => _wrapped?.Id;
 
         public override Response Value => SyncValue;
@@ -62,22 +56,58 @@ namespace azure_proto_core
 
         public override bool HasValue => CompletedSynchronously || _wrapped.HasValue;
 
-        public override Response GetRawResponse() => CompletedSynchronously ? SyncValue : _wrapped.GetRawResponse();
+        public override Response GetRawResponse()
+        {
+            return CompletedSynchronously ? SyncValue : _wrapped.GetRawResponse();
+        }
 
-        public override Response UpdateStatus(CancellationToken cancellationToken = default) => CompletedSynchronously ? SyncValue : _wrapped.UpdateStatus(cancellationToken);
+        public override Response UpdateStatus(CancellationToken cancellationToken = default)
+        {
+            return CompletedSynchronously ? SyncValue : _wrapped.UpdateStatus(cancellationToken);
+        }
 
-        public async override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default)
-            => CompletedSynchronously ? SyncValue : await _wrapped.UpdateStatusAsync(cancellationToken);
+        public override async ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default)
+        {
+            return CompletedSynchronously ? SyncValue : await _wrapped.UpdateStatusAsync(cancellationToken);
+        }
 
-        public async override ValueTask<Response<Response>> WaitForCompletionAsync(CancellationToken cancellationToken = default)
-            => CompletedSynchronously ? new WrappingResponse(SyncValue) : await _wrapped.WaitForCompletionAsync(cancellationToken);
+        public override async ValueTask<Response<Response>> WaitForCompletionAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return CompletedSynchronously
+                ? new WrappingResponse(SyncValue)
+                : await _wrapped.WaitForCompletionAsync(cancellationToken);
+        }
 
-        public async override ValueTask<Response<Response>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken) 
-            => CompletedSynchronously ? new WrappingResponse(SyncValue) : await _wrapped.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        public override async ValueTask<Response<Response>> WaitForCompletionAsync(
+            TimeSpan pollingInterval,
+            CancellationToken cancellationToken)
+        {
+            return CompletedSynchronously
+                ? new WrappingResponse(SyncValue)
+                : await _wrapped.WaitForCompletionAsync(pollingInterval, cancellationToken);
+        }
+
+        internal class WrappingResponse : ArmResponse<Response>
+        {
+            private readonly Response _wrapped;
+
+            public WrappingResponse(Response wrapped)
+            {
+                _wrapped = wrapped;
+            }
+
+            public override Response Value => _wrapped;
+
+            public override Response GetRawResponse()
+            {
+                return _wrapped;
+            }
+        }
     }
 
     /// <summary>
-    /// TODO: GENERATOR Reimplement this class without wrapping the underlying Operation
+    ///     TODO: GENERATOR Reimplement this class without wrapping the underlying Operation
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <typeparam name="U"></typeparam>
@@ -85,17 +115,19 @@ namespace azure_proto_core
         where TOperations : class
         where TModel : class
     {
-        Operation<TModel> _wrapped;
-        Func<TModel, TOperations> _converter;
-        Response<TModel> _syncWrapped;
+        private readonly Func<TModel, TOperations> _converter;
+        private readonly Response<TModel> _syncWrapped;
+        private readonly Operation<TModel> _wrapped;
 
-        public PhArmOperation(Operation<TModel> wrapped, Func<TModel, TOperations> converter) : base(null)
+        public PhArmOperation(Operation<TModel> wrapped, Func<TModel, TOperations> converter)
+            : base(null)
         {
             _wrapped = wrapped;
             _converter = converter;
         }
 
-        public PhArmOperation(Response<TModel> wrapped, Func<TModel, TOperations> converter) : base(converter(wrapped.Value))
+        public PhArmOperation(Response<TModel> wrapped, Func<TModel, TOperations> converter)
+            : base(converter(wrapped.Value))
         {
             _converter = converter;
             _syncWrapped = wrapped;
@@ -109,20 +141,42 @@ namespace azure_proto_core
 
         public override bool HasValue => CompletedSynchronously || _wrapped.HasValue;
 
-        public override Response GetRawResponse() => CompletedSynchronously ? _syncWrapped.GetRawResponse() : _wrapped.GetRawResponse();
+        public override Response GetRawResponse()
+        {
+            return CompletedSynchronously ? _syncWrapped.GetRawResponse() : _wrapped.GetRawResponse();
+        }
 
-        public override Response UpdateStatus(CancellationToken cancellationToken = default) 
-            => CompletedSynchronously ? _syncWrapped.GetRawResponse() : _wrapped.UpdateStatus(cancellationToken);
+        public override Response UpdateStatus(CancellationToken cancellationToken = default)
+        {
+            return CompletedSynchronously ? _syncWrapped.GetRawResponse() : _wrapped.UpdateStatus(cancellationToken);
+        }
 
-        public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default) 
-            => CompletedSynchronously ? new ValueTask<Response>(_syncWrapped.GetRawResponse()) : _wrapped.UpdateStatusAsync(cancellationToken);
+        public override ValueTask<Response> UpdateStatusAsync(CancellationToken cancellationToken = default)
+        {
+            return CompletedSynchronously
+                ? new ValueTask<Response>(_syncWrapped.GetRawResponse())
+                : _wrapped.UpdateStatusAsync(cancellationToken);
+        }
 
-        public async override ValueTask<Response<TOperations>> WaitForCompletionAsync(CancellationToken cancellationToken = default)
-            => CompletedSynchronously ? new PhArmResponse<TOperations, TModel>(_syncWrapped, _converter)
-            : new PhArmResponse<TOperations, TModel>( await _wrapped.WaitForCompletionAsync(cancellationToken), _converter);
+        public override async ValueTask<Response<TOperations>> WaitForCompletionAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return CompletedSynchronously
+                ? new PhArmResponse<TOperations, TModel>(_syncWrapped, _converter)
+                : new PhArmResponse<TOperations, TModel>(
+                    await _wrapped.WaitForCompletionAsync(cancellationToken),
+                    _converter);
+        }
 
-        public async override ValueTask<Response<TOperations>> WaitForCompletionAsync(TimeSpan pollingInterval, CancellationToken cancellationToken) 
-            => CompletedSynchronously ? new PhArmResponse<TOperations, TModel>(_syncWrapped, _converter)
-            : new PhArmResponse<TOperations, TModel>(await _wrapped.WaitForCompletionAsync(pollingInterval, cancellationToken), _converter);
+        public override async ValueTask<Response<TOperations>> WaitForCompletionAsync(
+            TimeSpan pollingInterval,
+            CancellationToken cancellationToken)
+        {
+            return CompletedSynchronously
+                ? new PhArmResponse<TOperations, TModel>(_syncWrapped, _converter)
+                : new PhArmResponse<TOperations, TModel>(
+                    await _wrapped.WaitForCompletionAsync(pollingInterval, cancellationToken),
+                    _converter);
+        }
     }
 }

--- a/azure-proto-core/ArmResourceOperations.cs
+++ b/azure-proto-core/ArmResourceOperations.cs
@@ -1,33 +1,27 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 
 namespace azure_proto_core
 {
-    public class ArmResourceOperations : ResourceOperationsBase<ArmResourceOperations, ArmResource>, ITaggable<ArmResourceOperations, ArmResource>, IDeletableResource<ArmResourceOperations, ArmResource>
+    public class ArmResourceOperations : ResourceOperationsBase<ArmResourceOperations, ArmResource>,
+        ITaggable<ArmResourceOperations, ArmResource>, IDeletableResource<ArmResourceOperations, ArmResource>
     {
-        public ArmResourceOperations(ArmClientContext context, ResourceIdentifier id) : base(context, id) { }
-
-        public ArmResourceOperations(ArmClientContext context, ArmResource resource) : base(context, resource) { }
-
-        public override void Validate(ResourceIdentifier identifier)
+        public ArmResourceOperations(ArmClientContext context, ResourceIdentifier id)
+            : base(context, id)
         {
-            //the id can be of any type so do nothing
         }
 
-        //TODO: Fill out the methods using ResourceManagementClient 
-        public  ArmOperation<ArmResourceOperations> AddTag(string key, string value)
+        public ArmResourceOperations(ArmClientContext context, ArmResource resource)
+            : base(context, resource)
         {
-            throw new NotImplementedException();
         }
 
-        public  Task<ArmOperation<ArmResourceOperations>> AddTagAsync(string key, string value, CancellationToken cancellationToken = default)
-        {
-            throw new NotImplementedException();
-        }
-
-        public  ArmOperation<Response> Delete()
+        public ArmOperation<Response> Delete()
         {
             throw new NotImplementedException();
         }
@@ -35,6 +29,25 @@ namespace azure_proto_core
         public Task<ArmOperation<Response>> DeleteAsync(CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
+        }
+
+        // TODO: Fill out the methods using ResourceManagementClient
+        public ArmOperation<ArmResourceOperations> AddTag(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ArmOperation<ArmResourceOperations>> AddTagAsync(
+            string key,
+            string value,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Validate(ResourceIdentifier identifier)
+        {
+            //the id can be of any type so do nothing
         }
 
         public override ArmResponse<ArmResourceOperations> Get()

--- a/azure-proto-core/ArmResponse.cs
+++ b/azure-proto-core/ArmResponse.cs
@@ -1,4 +1,7 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure;
 
 namespace azure_proto_core
 {
@@ -8,7 +11,7 @@ namespace azure_proto_core
 
     public class ArmVoidResponse : ArmResponse<Response>
     {
-        private Response _response;
+        private readonly Response _response;
 
         public ArmVoidResponse(Response response)
         {

--- a/azure-proto-core/DeletableResourceOperations.cs
+++ b/azure-proto-core/DeletableResourceOperations.cs
@@ -1,14 +1,18 @@
-using Azure;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Threading;
 using System.Threading.Tasks;
+using Azure;
 
 namespace azure_proto_core
 {
-    public interface IDeletableResource<TOperations, TResource> 
-        where TResource:Resource 
-        where TOperations: IDeletableResource<TOperations, TResource>
+    public interface IDeletableResource<TOperations, TResource>
+        where TResource : Resource
+        where TOperations : IDeletableResource<TOperations, TResource>
     {
         ArmOperation<Response> Delete();
+
         Task<ArmOperation<Response>> DeleteAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/azure-proto-core/OperationsBase.cs
+++ b/azure-proto-core/OperationsBase.cs
@@ -1,14 +1,20 @@
-﻿using Azure.Core;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
+using Azure.Core;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// TODO: split this into a base class for all Operations, and a base class for specific operations
+    ///     TODO: split this into a base class for all Operations, and a base class for specific operations
     /// </summary>
     public abstract class OperationsBase
     {
-        public OperationsBase(ArmClientContext context, ResourceIdentifier id, Location location = null) : this(context, new ArmResource(id, location ?? Location.Default)) { }
+        public OperationsBase(ArmClientContext context, ResourceIdentifier id, Location location = null)
+            : this(context, new ArmResource(id, location ?? Location.Default))
+        {
+        }
 
         public OperationsBase(ArmClientContext context, Resource resource)
         {
@@ -16,7 +22,7 @@ namespace azure_proto_core
 
             ClientContext = context;
             Id = resource.Id;
-            TrackedResource trackedResource = resource as TrackedResource;
+            var trackedResource = resource as TrackedResource;
             DefaultLocation = trackedResource?.Location ?? Location.Default;
             Resource = resource;
         }
@@ -40,14 +46,15 @@ namespace azure_proto_core
         }
 
         /// <summary>
-        /// Note that this is currently adapting to underlying management clients - once generator changes are in, this would likely be unnecessary
+        ///     Note that this is currently adapting to underlying management clients - once generator changes are in, this would
+        ///     likely be unnecessary
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="creator"></param>
         /// <returns></returns>
         protected T GetClient<T>(Func<Uri, TokenCredential, T> creator)
         {
-            return ClientContext.GetClient<T>(creator);
+            return ClientContext.GetClient(creator);
         }
     }
 }

--- a/azure-proto-core/Placeholder/PhLocation.cs
+++ b/azure-proto-core/Placeholder/PhLocation.cs
@@ -1,22 +1,24 @@
-﻿using azure_proto_core;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace azure_proto_core
 {
     // Update the signature for new library
     public class PhLocation : TrackedResource<Azure.ResourceManager.Resources.Models.Location>
     {
-        
-        public PhLocation(Azure.ResourceManager.Resources.Models.Location loc) : base(loc.Id, loc.Name, loc)
+        public PhLocation(Azure.ResourceManager.Resources.Models.Location loc)
+            : base(loc.Id, loc.Name, loc)
         {
         }
 
         public override string Name => Model.Name;
+
         public string SubscriptionId => Model.SubscriptionId;
+
         public string DisplayName => Model.DisplayName;
+
         public string Latitude => Model.Metadata.Latitude;
+
         public string Longitude => Model.Metadata.Longitude;
     }
 }

--- a/azure-proto-core/Placeholder/PhResourceGroup.cs
+++ b/azure-proto-core/Placeholder/PhResourceGroup.cs
@@ -1,15 +1,16 @@
-﻿using azure_proto_core;
-using Azure.ResourceManager.Resources.Models;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
-using System.Text;
+using Azure.ResourceManager.Resources.Models;
 
 namespace azure_proto_core
 {
     public class PhResourceGroup : TrackedResource<ResourceGroup>, IManagedByResource
     {
-
-        public PhResourceGroup(ResourceGroup rg) : base(rg.Id, rg.Location, rg)
+        public PhResourceGroup(ResourceGroup rg)
+            : base(rg.Id, rg.Location, rg)
         {
             if (null == rg.Tags)
             {
@@ -18,12 +19,15 @@ namespace azure_proto_core
         }
 
         public override IDictionary<string, string> Tags => Model.Tags;
+
         public override string Name => Model.Name;
+
         public ResourceGroupProperties Properties
         {
             get => Model.Properties;
             set => Model.Properties = value;
         }
+
         public string ManagedBy
         {
             get => Model.ManagedBy;

--- a/azure-proto-core/Placeholder/PhSubscriptionModel.cs
+++ b/azure-proto-core/Placeholder/PhSubscriptionModel.cs
@@ -1,23 +1,27 @@
-﻿using azure_proto_core;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Azure.ResourceManager.Resources.Models;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace azure_proto_core
 {
     public class PhSubscriptionModel : TrackedResource<Subscription>
     {
-        public PhSubscriptionModel(Subscription s) : base(s.Id, null, s)
+        public PhSubscriptionModel(Subscription s)
+            : base(s.Id, null, s)
         {
         }
 
         public override string Name => Model.SubscriptionId;
-        public string SubscriptionId => Model.SubscriptionId;
-        public string DisplayName => Model.DisplayName;
-        public SubscriptionState? State => Model.State;
-        public SubscriptionPolicies SubscriptionPolicies => Model.SubscriptionPolicies;
-        public string AuthorizationSource => Model.AuthorizationSource;
 
+        public string SubscriptionId => Model.SubscriptionId;
+
+        public string DisplayName => Model.DisplayName;
+
+        public SubscriptionState? State => Model.State;
+
+        public SubscriptionPolicies SubscriptionPolicies => Model.SubscriptionPolicies;
+
+        public string AuthorizationSource => Model.AuthorizationSource;
     }
 }

--- a/azure-proto-core/ResourceContainerOperations.cs
+++ b/azure-proto-core/ResourceContainerOperations.cs
@@ -1,45 +1,69 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Create known Container and Leaf scopes for ARM Containers
-    /// Think about how to extend known scope types in an extensible fashion (is it just adding them to the default, or is it having scopes for all provider or consumer services?
-    /// For example, INetworkConsumer, IDatabaseConsumer, IEncryptionConsumer, IControlConsumer, ITriggerConsumer which also allows you to attach at that scope? [AttachDatabase]
+    ///     Create known Container and Leaf scopes for ARM Containers
+    ///     Think about how to extend known scope types in an extensible fashion (is it just adding them to the default, or is
+    ///     it having scopes for all provider or consumer services?
+    ///     For example, INetworkConsumer, IDatabaseConsumer, IEncryptionConsumer, IControlConsumer, ITriggerConsumer which
+    ///     also allows you to attach at that scope? [AttachDatabase]
     /// </summary>
     /// <typeparam name="T">The type of the resource model</typeparam>
-    /// <typeparam name="U">The return type of the Creation methods, this can be Response<typeparamref name="T"/> or a long-running response</typeparam>
+    /// <typeparam name="U">
+    ///     The return type of the Creation methods, this can be Response<typeparamref name="T" /> or a
+    ///     long-running response
+    /// </typeparam>
     public abstract class ResourceContainerOperations<TOperations, TResource> : OperationsBase
-        where TOperations :  ResourceOperationsBase<TOperations, TResource>
+        where TOperations : ResourceOperationsBase<TOperations, TResource>
         where TResource : Resource
     {
-        protected TrackedResource Parent { get; private set; }
-
-        protected ResourceContainerOperations(ArmClientContext context, ResourceIdentifier id) : base(context, id)
+        protected ResourceContainerOperations(ArmClientContext context, ResourceIdentifier id)
+            : base(context, id)
         {
         }
 
-        protected ResourceContainerOperations(ArmClientContext context, TrackedResource resource) : base(context, resource)
+        protected ResourceContainerOperations(ArmClientContext context, TrackedResource resource)
+            : base(context, resource)
         {
             Parent = resource;
         }
 
+        protected TrackedResource Parent { get; }
+
         public override void Validate(ResourceIdentifier identifier)
         {
-            if (identifier.Type != ResourceGroupOperations.AzureResourceType && identifier.Type != SubscriptionOperations.AzureResourceType && identifier.Type != ResourceType.Parent)
+            if (identifier.Type != ResourceGroupOperations.AzureResourceType &&
+                identifier.Type != SubscriptionOperations.AzureResourceType &&
+                identifier.Type != ResourceType.Parent)
             {
                 throw new InvalidOperationException($"{identifier.Type} is not a valid container for {ResourceType}");
             }
         }
 
-        public abstract ArmResponse<TOperations> Create(string name, TResource resourceDetails, CancellationToken cancellationToken = default);
+        public abstract ArmResponse<TOperations> Create(
+            string name,
+            TResource resourceDetails,
+            CancellationToken cancellationToken = default);
 
-        public abstract Task<ArmResponse<TOperations>> CreateAsync(string name, TResource resourceDetails, CancellationToken cancellationToken = default);
+        public abstract Task<ArmResponse<TOperations>> CreateAsync(
+            string name,
+            TResource resourceDetails,
+            CancellationToken cancellationToken = default);
 
-        public abstract ArmOperation<TOperations> StartCreate(string name, TResource resourceDetails, CancellationToken cancellationToken = default);
+        public abstract ArmOperation<TOperations> StartCreate(
+            string name,
+            TResource resourceDetails,
+            CancellationToken cancellationToken = default);
 
-        public abstract Task<ArmOperation<TOperations>> StartCreateAsync(string name, TResource resourceDetails, CancellationToken cancellationToken = default);
+        public abstract Task<ArmOperation<TOperations>> StartCreateAsync(
+            string name,
+            TResource resourceDetails,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/azure-proto-core/ResourceGroupContainerOperations.cs
+++ b/azure-proto-core/ResourceGroupContainerOperations.cs
@@ -1,76 +1,103 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
 using azure_proto_core.Adapters;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Operations for the RespourceGroups container in the given subscription context.  Allows Creating and listign respource groups
-    /// and provides an attachment point for Collections of Tracked Resources.
+    ///     Operations for the RespourceGroups container in the given subscription context.  Allows Creating and listign
+    ///     respource groups
+    ///     and provides an attachment point for Collections of Tracked Resources.
     /// </summary>
     public class ResourceGroupContainerOperations : ResourceContainerOperations<XResourceGroup, PhResourceGroup>
     {
+        internal ResourceGroupContainerOperations(ArmClientContext context, SubscriptionOperations subscription)
+            : base(context, subscription.Id)
+        {
+        }
+
+        internal ResourceGroupContainerOperations(ArmClientContext context, ResourceIdentifier id)
+            : base(context, id)
+        {
+        }
+
         public override ResourceType ResourceType => "Microsoft.Resources/resourceGroups";
 
-        internal ResourceGroupContainerOperations(ArmClientContext context, SubscriptionOperations subscription) : base(context, subscription.Id) { }
-
-        internal ResourceGroupContainerOperations(ArmClientContext context, ResourceIdentifier id) : base(context, id) { }
+        internal ResourceGroupsOperations Operations =>
+            GetClient((uri, cred) => new ResourcesManagementClient(uri, Id.Subscription, cred)).ResourceGroups;
 
         public ArmOperation<XResourceGroup> Create(string name, Location location)
         {
             var model = new PhResourceGroup(new ResourceGroup(location));
+
             return new PhArmOperation<XResourceGroup, ResourceGroup>(
                 Operations.CreateOrUpdate(name, model),
                 g => new XResourceGroup(ClientContext, new PhResourceGroup(g)));
         }
 
-        public override ArmResponse<XResourceGroup> Create(string name, PhResourceGroup resourceDetails, CancellationToken cancellationToken = default)
+        public override ArmResponse<XResourceGroup> Create(
+            string name,
+            PhResourceGroup resourceDetails,
+            CancellationToken cancellationToken = default)
         {
             var response = Operations.CreateOrUpdate(name, resourceDetails, cancellationToken);
+
             return new PhArmResponse<XResourceGroup, ResourceGroup>(
                 response,
                 g => new XResourceGroup(ClientContext, new PhResourceGroup(g)));
         }
 
-        public async override Task<ArmResponse<XResourceGroup>> CreateAsync(string name, PhResourceGroup resourceDetails, CancellationToken cancellationToken = default)
+        public override async Task<ArmResponse<XResourceGroup>> CreateAsync(
+            string name,
+            PhResourceGroup resourceDetails,
+            CancellationToken cancellationToken = default)
         {
-            var response = await Operations.CreateOrUpdateAsync(name, resourceDetails, cancellationToken).ConfigureAwait(false);
+            var response = await Operations.CreateOrUpdateAsync(name, resourceDetails, cancellationToken)
+                .ConfigureAwait(false);
+
             return new PhArmResponse<XResourceGroup, ResourceGroup>(
                 response,
                 g => new XResourceGroup(ClientContext, new PhResourceGroup(g)));
         }
 
-        public override ArmOperation<XResourceGroup> StartCreate(string name, PhResourceGroup resourceDetails, CancellationToken cancellationToken = default)
+        public override ArmOperation<XResourceGroup> StartCreate(
+            string name,
+            PhResourceGroup resourceDetails,
+            CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<XResourceGroup, ResourceGroup>(
                 Operations.CreateOrUpdate(name, resourceDetails, cancellationToken),
                 g => new XResourceGroup(ClientContext, new PhResourceGroup(g)));
         }
 
-        public async override Task<ArmOperation<XResourceGroup>> StartCreateAsync(string name, PhResourceGroup resourceDetails, CancellationToken cancellationToken = default)
+        public override async Task<ArmOperation<XResourceGroup>> StartCreateAsync(
+            string name,
+            PhResourceGroup resourceDetails,
+            CancellationToken cancellationToken = default)
         {
             return new PhArmOperation<XResourceGroup, ResourceGroup>(
                 await Operations.CreateOrUpdateAsync(name, resourceDetails, cancellationToken).ConfigureAwait(false),
                 g => new XResourceGroup(ClientContext, new PhResourceGroup(g)));
         }
 
-        public Pageable<XResourceGroup> List(CancellationToken cancellationToken = default(CancellationToken))
+        public Pageable<XResourceGroup> List(CancellationToken cancellationToken = default)
         {
             return new PhWrappingPageable<ResourceGroup, XResourceGroup>(
                 Operations.List(null, null, cancellationToken),
                 s => new XResourceGroup(ClientContext, new PhResourceGroup(s)));
         }
 
-        public AsyncPageable<XResourceGroup> ListAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public AsyncPageable<XResourceGroup> ListAsync(CancellationToken cancellationToken = default)
         {
             return new PhWrappingAsyncPageable<ResourceGroup, XResourceGroup>(
                 Operations.ListAsync(null, null, cancellationToken),
                 s => new XResourceGroup(ClientContext, new PhResourceGroup(s)));
         }
-
-        internal ResourceGroupsOperations Operations => GetClient<ResourcesManagementClient>((uri, cred) => new ResourcesManagementClient(uri, Id.Subscription, cred)).ResourceGroups;
     }
 }

--- a/azure-proto-core/ResourceListOperations.cs
+++ b/azure-proto-core/ResourceListOperations.cs
@@ -1,60 +1,116 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
 using azure_proto_core.Adapters;
 using azure_proto_core.Resources;
-using System;
-using System.Collections.Generic;
-using System.Threading;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Generic list operations class - can be extended if a specific RP has more list operations
+    ///     Generic list operations class - can be extended if a specific RP has more list operations
     /// </summary>
     public class ResourceListOperations
     {
         private static void Validate(ResourceIdentifier id)
         {
-            if (id.Type != ResourceGroupOperations.AzureResourceType && id.Type != SubscriptionOperations.AzureResourceType)
-                throw new ArgumentException($"{id.Type} is not valid to list at context must be {ResourceGroupOperations.AzureResourceType} or {SubscriptionOperations.AzureResourceType}");
+            if (id.Type != ResourceGroupOperations.AzureResourceType &&
+                id.Type != SubscriptionOperations.AzureResourceType)
+            {
+                throw new ArgumentException(
+                    $"{id.Type} is not valid to list at context must be {ResourceGroupOperations.AzureResourceType} or {SubscriptionOperations.AzureResourceType}");
+            }
         }
 
-        public static Pageable<TOperations> ListAtContext<TOperations, TResource>(ArmClientContext clientContext, ResourceIdentifier id, ArmFilterCollection resourceFilters = null, int? top = null, CancellationToken cancellationToken = default)
+        public static Pageable<TOperations> ListAtContext<TOperations, TResource>(
+            ArmClientContext clientContext,
+            ResourceIdentifier id,
+            ArmFilterCollection resourceFilters = null,
+            int? top = null,
+            CancellationToken cancellationToken = default)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
             Validate(id);
 
-            string scopeId = id.Type == ResourceGroupOperations.AzureResourceType ? id.Name : null;
-            return _ListAtContext<TOperations, TResource>(clientContext, id, scopeId, resourceFilters, top, cancellationToken);
+            var scopeId = id.Type == ResourceGroupOperations.AzureResourceType ? id.Name : null;
+
+            return _ListAtContext<TOperations, TResource>(
+                clientContext,
+                id,
+                scopeId,
+                resourceFilters,
+                top,
+                cancellationToken);
         }
 
-        public static AsyncPageable<TOperations> ListAtContextAsync<TOperations, TResource>(ArmClientContext clientContext, ResourceIdentifier id, ArmFilterCollection resourceFilters = null, int? top = null, CancellationToken cancellationToken = default)
+        public static AsyncPageable<TOperations> ListAtContextAsync<TOperations, TResource>(
+            ArmClientContext clientContext,
+            ResourceIdentifier id,
+            ArmFilterCollection resourceFilters = null,
+            int? top = null,
+            CancellationToken cancellationToken = default)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
             Validate(id);
 
-            string scopeId = id.Type == ResourceGroupOperations.AzureResourceType ? id.Name : null;
-            return _ListAtContextAsync<TOperations, TResource>(clientContext, id, scopeId, resourceFilters, top, cancellationToken);
+            var scopeId = id.Type == ResourceGroupOperations.AzureResourceType ? id.Name : null;
+
+            return _ListAtContextAsync<TOperations, TResource>(
+                clientContext,
+                id,
+                scopeId,
+                resourceFilters,
+                top,
+                cancellationToken);
         }
 
-        public static Pageable<TOperations> ListAtContext<TOperations, TResource>(SubscriptionOperations subscription, ArmFilterCollection resourceFilters = null, int? top = null, CancellationToken cancellationToken = default)
+        public static Pageable<TOperations> ListAtContext<TOperations, TResource>(
+            SubscriptionOperations subscription,
+            ArmFilterCollection resourceFilters = null,
+            int? top = null,
+            CancellationToken cancellationToken = default)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
-            return _ListAtContext<TOperations, TResource>(subscription.ClientContext, subscription.Id, null, resourceFilters, top, cancellationToken);
+            return _ListAtContext<TOperations, TResource>(
+                subscription.ClientContext,
+                subscription.Id,
+                null,
+                resourceFilters,
+                top,
+                cancellationToken);
         }
 
-        public static AsyncPageable<TOperations> ListAtContextAsync<TOperations, TResource>(SubscriptionOperations subscription, ArmFilterCollection resourceFilters = null, int? top = null, CancellationToken cancellationToken = default)
+        public static AsyncPageable<TOperations> ListAtContextAsync<TOperations, TResource>(
+            SubscriptionOperations subscription,
+            ArmFilterCollection resourceFilters = null,
+            int? top = null,
+            CancellationToken cancellationToken = default)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
-            return _ListAtContextAsync<TOperations, TResource>(subscription.ClientContext, subscription.Id, null, resourceFilters, top, cancellationToken);
+            return _ListAtContextAsync<TOperations, TResource>(
+                subscription.ClientContext,
+                subscription.Id,
+                null,
+                resourceFilters,
+                top,
+                cancellationToken);
         }
 
-        private static AsyncPageable<TOperations> _ListAtContextAsync<TOperations, TResource>(ArmClientContext clientContext, ResourceIdentifier scopeId, string scopeFilter, ArmFilterCollection resourceFilters = null, int? top = null, CancellationToken cancellationToken = default)
+        private static AsyncPageable<TOperations> _ListAtContextAsync<TOperations, TResource>(
+            ArmClientContext clientContext,
+            ResourceIdentifier scopeId,
+            string scopeFilter,
+            ArmFilterCollection resourceFilters = null,
+            int? top = null,
+            CancellationToken cancellationToken = default)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
@@ -66,31 +122,49 @@ namespace azure_proto_core
             }
             else
             {
-                result = resourceOperations.ListByResourceGroupAsync(scopeFilter, resourceFilters?.ToString(), null, top, cancellationToken);
+                result = resourceOperations.ListByResourceGroupAsync(
+                    scopeFilter,
+                    resourceFilters?.ToString(),
+                    null,
+                    top,
+                    cancellationToken);
             }
 
             return ConvertResultsAsync<TOperations, TResource>(result, clientContext);
         }
 
-        private static Pageable<TOperations> _ListAtContext<TOperations, TResource>(ArmClientContext clientContext, ResourceIdentifier scopeId, string scopeFilter = null, ArmFilterCollection resourceFilters = null, int? top = null, CancellationToken cancellationToken = default)
+        private static Pageable<TOperations> _ListAtContext<TOperations, TResource>(
+            ArmClientContext clientContext,
+            ResourceIdentifier scopeId,
+            string scopeFilter = null,
+            ArmFilterCollection resourceFilters = null,
+            int? top = null,
+            CancellationToken cancellationToken = default)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
             var resourceOperations = GetResourcesClient(clientContext, scopeId.Subscription).Resources;
             Pageable<GenericResourceExpanded> result;
-            if(scopeFilter == null)
+            if (scopeFilter == null)
             {
                 result = resourceOperations.List(resourceFilters?.ToString(), null, top, cancellationToken);
             }
             else
             {
-                result = resourceOperations.ListByResourceGroup(scopeFilter, resourceFilters?.ToString(), null, top, cancellationToken);
+                result = resourceOperations.ListByResourceGroup(
+                    scopeFilter,
+                    resourceFilters?.ToString(),
+                    null,
+                    top,
+                    cancellationToken);
             }
 
             return ConvertResults<TOperations, TResource>(result, clientContext);
         }
 
-        private static Pageable<TOperations> ConvertResults<TOperations, TResource>(Pageable<GenericResourceExpanded> result, ArmClientContext clientContext)
+        private static Pageable<TOperations> ConvertResults<TOperations, TResource>(
+            Pageable<GenericResourceExpanded> result,
+            ArmClientContext clientContext)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
@@ -99,10 +173,14 @@ namespace azure_proto_core
                 s => Activator.CreateInstance(
                     typeof(TOperations),
                     clientContext,
-                    (Activator.CreateInstance(typeof(TResource), s as Azure.ResourceManager.Resources.Models.Resource) as TResource).Id) as TOperations);
+                    (Activator.CreateInstance(
+                        typeof(TResource),
+                        s as Azure.ResourceManager.Resources.Models.Resource) as TResource).Id) as TOperations);
         }
 
-        private static AsyncPageable<TOperations> ConvertResultsAsync<TOperations, TResource>(AsyncPageable<GenericResourceExpanded> result, ArmClientContext clientContext)
+        private static AsyncPageable<TOperations> ConvertResultsAsync<TOperations, TResource>(
+            AsyncPageable<GenericResourceExpanded> result,
+            ArmClientContext clientContext)
             where TOperations : ResourceOperationsBase<TOperations, TResource>
             where TResource : TrackedResource
         {
@@ -111,7 +189,8 @@ namespace azure_proto_core
                 s => Activator.CreateInstance(
                     typeof(TOperations),
                     clientContext,
-                    Activator.CreateInstance(typeof(TResource), s as Azure.ResourceManager.Resources.Models.Resource) as TResource) as TOperations);
+                    Activator.CreateInstance(typeof(TResource), s as Azure.ResourceManager.Resources.Models.Resource) as
+                        TResource) as TOperations);
         }
 
         //TODO: should be able to access context.GetClient() instead of needing this method

--- a/azure-proto-core/ResourceOperationsBase.cs
+++ b/azure-proto-core/ResourceOperationsBase.cs
@@ -1,17 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace azure_proto_core
 {
-    public abstract class ResourceOperationsBase<TOperations, TResource> : OperationsBase 
-        where TResource : Resource 
+    public abstract class ResourceOperationsBase<TOperations, TResource> : OperationsBase
+        where TResource : Resource
         where TOperations : ResourceOperationsBase<TOperations, TResource>
     {
-        public ResourceOperationsBase(ArmResourceOperations genericOperations) : this(genericOperations.ClientContext, genericOperations.Id) { }
+        public ResourceOperationsBase(ArmResourceOperations genericOperations)
+            : this(genericOperations.ClientContext, genericOperations.Id)
+        {
+        }
 
-        public ResourceOperationsBase(ArmClientContext context, ResourceIdentifier id) : this(context, new ArmResource(id)) { }
+        public ResourceOperationsBase(ArmClientContext context, ResourceIdentifier id)
+            : this(context, new ArmResource(id))
+        {
+        }
 
-        public ResourceOperationsBase(ArmClientContext context, Resource resource) : base(context, resource) { }
+        public ResourceOperationsBase(ArmClientContext context, Resource resource)
+            : base(context, resource)
+        {
+        }
 
         public abstract ArmResponse<TOperations> Get();
 

--- a/azure-proto-core/Resources/ArmResource.cs
+++ b/azure-proto-core/Resources/ArmResource.cs
@@ -1,7 +1,10 @@
-﻿namespace azure_proto_core
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace azure_proto_core
 {
     /// <summary>
-    /// Generic representation of an ARM resource.  Resources in the ARM RP should extend this resource.
+    ///     Generic representation of an ARM resource.  Resources in the ARM RP should extend this resource.
     /// </summary>
     public class ArmResource : TrackedResource, IManagedByResource, ISkuResource
     {
@@ -10,7 +13,7 @@
             Id = genericResource.Id;
             Location = genericResource.Location;
             Tags.Clear();
-            foreach(var tag in genericResource.Tags)
+            foreach (var tag in genericResource.Tags)
             {
                 Tags.Add(tag);
             }
@@ -29,10 +32,13 @@
         }
 
         public override ResourceIdentifier Id { get; protected set; }
-        public string ManagedBy { get; set; }
-        public Sku Sku { get; set; }
-        public Plan Plan { get; set; }
-        public string Kind { get; set; }
 
+        public string ManagedBy { get; set; }
+
+        public Sku Sku { get; set; }
+
+        public Plan Plan { get; set; }
+
+        public string Kind { get; set; }
     }
 }

--- a/azure-proto-core/Resources/ArmResourceFilter.cs
+++ b/azure-proto-core/Resources/ArmResourceFilter.cs
@@ -1,21 +1,21 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 
 namespace azure_proto_core.Resources
 {
     /// <summary>
-    /// Syntactic sugar for creating ARM filters
+    ///     Syntactic sugar for creating ARM filters
     /// </summary>
     public abstract class ArmResourceFilter : IEquatable<string>, IEquatable<ArmResourceFilter>
     {
-        public ArmResourceFilter()
-        {
-        }
+        public abstract bool Equals(ArmResourceFilter other);
+
         public abstract bool Equals(string other);
 
         public abstract string GetFilterString();
-
-        public abstract bool Equals(ArmResourceFilter other);
 
         public override string ToString()
         {
@@ -28,6 +28,16 @@ namespace azure_proto_core.Resources
         public string Name { get; set; }
 
         public string ResourceGroup { get; set; }
+
+        /// <summary>
+        /// gfhgfhf hjgjhgjhg
+        /// </summary>
+        /// <param name="nameString">hgjhg hjhgjh</param>
+        public static implicit operator ArmSubstringFilter(string nameString)
+        {
+            return new ArmSubstringFilter { Name = nameString };
+        }
+
         public override bool Equals(string other)
         {
             throw new NotImplementedException();
@@ -53,8 +63,6 @@ namespace azure_proto_core.Resources
 
             return string.Join(" and ", builder);
         }
-
-        public static implicit operator ArmSubstringFilter(string nameString) => new ArmSubstringFilter { Name = nameString };
     }
 
     public class ArmResourceTypeFilter : ArmResourceFilter
@@ -84,10 +92,7 @@ namespace azure_proto_core.Resources
 
     public class ArmTagFilter : ArmResourceFilter
     {
-        Tuple<string, string> _tag;
-
-        public string Key { get; private set; }
-        public string Value { get; private set; }
+        private readonly Tuple<string, string> _tag;
 
         public ArmTagFilter(Tuple<string, string> tag)
         {
@@ -96,7 +101,14 @@ namespace azure_proto_core.Resources
             Value = _tag.Item2;
         }
 
-        public ArmTagFilter(string tagKey, string tagValue) : this(new Tuple<string, string>(tagKey, tagValue)) { }
+        public ArmTagFilter(string tagKey, string tagValue)
+            : this(new Tuple<string, string>(tagKey, tagValue))
+        {
+        }
+
+        public string Key { get; }
+
+        public string Value { get; }
 
         public override bool Equals(string other)
         {
@@ -116,7 +128,9 @@ namespace azure_proto_core.Resources
 
     public class ArmFilterCollection
     {
-        public ArmFilterCollection() { }
+        public ArmFilterCollection()
+        {
+        }
 
         public ArmFilterCollection(ResourceType type)
         {

--- a/azure-proto-core/Resources/IEntityResource.cs
+++ b/azure-proto-core/Resources/IEntityResource.cs
@@ -1,7 +1,10 @@
-﻿namespace azure_proto_core
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace azure_proto_core
 {
     /// <summary>
-    /// Represents a resource that supports entity tags.  We *may* want to make this a separate type
+    ///     Represents a resource that supports entity tags.  We *may* want to make this a separate type
     /// </summary>
     public interface IEntityResource
     {

--- a/azure-proto-core/Resources/IManagedByResource.cs
+++ b/azure-proto-core/Resources/IManagedByResource.cs
@@ -1,7 +1,10 @@
-﻿namespace azure_proto_core
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace azure_proto_core
 {
     /// <summary>
-    /// Resource managed by another resource
+    ///     Resource managed by another resource
     /// </summary>
     public interface IManagedByResource
     {

--- a/azure-proto-core/Resources/IManagedIdentity.cs
+++ b/azure-proto-core/Resources/IManagedIdentity.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Resource that uses MSI
+    ///     Resource that uses MSI
     /// </summary>
     public interface IManagedIdentity
     {

--- a/azure-proto-core/Resources/IPatchModel.cs
+++ b/azure-proto-core/Resources/IPatchModel.cs
@@ -1,11 +1,12 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System.Collections.Generic;
-using System.Text;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Placeholder for ARM Patch operations
+    ///     Placeholder for ARM Patch operations
     /// </summary>
     public interface IPatchModel
     {

--- a/azure-proto-core/Resources/IPrivateEndpointProvider.cs
+++ b/azure-proto-core/Resources/IPrivateEndpointProvider.cs
@@ -1,10 +1,12 @@
-﻿namespace azure_proto_core
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace azure_proto_core
 {
     /// <summary>
-    /// Terminus of a private link - design TBD
+    ///     Terminus of a private link - design TBD
     /// </summary>
     public interface IPrivateEndpointProvider
     {
-
     }
 }

--- a/azure-proto-core/Resources/ISkuResource.cs
+++ b/azure-proto-core/Resources/ISkuResource.cs
@@ -1,16 +1,23 @@
-﻿namespace azure_proto_core
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace azure_proto_core
 {
     /// <summary>
-    /// Resource that uses SKU
-    /// TODO: GENERATOR Note that it is unclear whether we get value from these interfaces, using these as a placeholder, this
-    /// could just be generated code with supporting types for entities like 'plan'.  The determinitive factor should be
-    /// if the additional type structure enables a desirable generic treatment of resources.  Initial thought is that 
-    /// Managed Identity, Private Link and Entity Tags would beneft fromt he extra OM here, but that ManagedBy and Sku do not.
+    ///     Resource that uses SKU
+    ///     TODO: GENERATOR Note that it is unclear whether we get value from these interfaces, using these as a placeholder,
+    ///     this
+    ///     could just be generated code with supporting types for entities like 'plan'.  The determinitive factor should be
+    ///     if the additional type structure enables a desirable generic treatment of resources.  Initial thought is that
+    ///     Managed Identity, Private Link and Entity Tags would beneft fromt he extra OM here, but that ManagedBy and Sku do
+    ///     not.
     /// </summary>
     public interface ISkuResource
     {
         Sku Sku { get; set; }
+
         Plan Plan { get; set; }
+
         string Kind { get; set; }
     }
 }

--- a/azure-proto-core/Resources/Identity.cs
+++ b/azure-proto-core/Resources/Identity.cs
@@ -1,11 +1,13 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Represents a managed identity
-    /// TODO: fill in properties, implement comparison and equality methods and operator overloads
+    ///     Represents a managed identity
+    ///     TODO: fill in properties, implement comparison and equality methods and operator overloads
     /// </summary>
     public class Identity : IEquatable<Identity>, IComparable<Identity>
     {

--- a/azure-proto-core/Resources/IdentityKind.cs
+++ b/azure-proto-core/Resources/IdentityKind.cs
@@ -1,59 +1,85 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Extensible representation of immutable identity kind.
+    ///     Extensible representation of immutable identity kind.
     /// </summary>
-    public struct IdentityKind : IEquatable<IdentityKind>, IEquatable<string>, IComparable<IdentityKind>, IComparable<string>
+    public struct IdentityKind : IEquatable<IdentityKind>, IEquatable<string>, IComparable<IdentityKind>,
+        IComparable<string>
     {
         public static readonly IdentityKind SystemAssigned = new IdentityKind("SystemAssigned");
         public static readonly IdentityKind UserAssigned = new IdentityKind("UserAssigned");
         public static readonly IdentityKind SystemAndUserAssigned = new IdentityKind("SystemAndUserAssigned");
+
         public IdentityKind(string kind)
         {
             Value = kind;
         }
 
-        public string Value { get; private set; }
+        public string Value { get; }
+
         public int CompareTo(IdentityKind other)
         {
-            if (this.Value == null && other.Value == null)
+            if (Value == null && other.Value == null)
+            {
                 return 0;
-            else if (this.Value == null)
+            }
+
+            if (Value == null)
+            {
                 return -1;
-            else
-                return this.Value.CompareTo(other.Value);
+            }
+
+            return Value.CompareTo(other.Value);
         }
 
         public int CompareTo(string other)
         {
-            if (this.Value == null && other == null)
+            if (Value == null && other == null)
+            {
                 return 0;
-            else if (this.Value == null)
+            }
+
+            if (Value == null)
+            {
                 return -1;
-            else
-                return this.Value.CompareTo(other);
+            }
+
+            return Value.CompareTo(other);
         }
 
         public bool Equals(IdentityKind other)
         {
-            if (this.Value == null && other.Value == null)
+            if (Value == null && other.Value == null)
+            {
                 return true;
-            else if (this.Value == null)
+            }
+
+            if (Value == null)
+            {
                 return false;
-            else
-                return this.Value.Equals(other.Value);
+            }
+
+            return Value.Equals(other.Value);
         }
 
         public bool Equals(string other)
         {
-            if (this.Value == null && other == null)
+            if (Value == null && other == null)
+            {
                 return true;
-            else if (this.Value == null)
+            }
+
+            if (Value == null)
+            {
                 return false;
-            else
-                return this.Value.Equals(other);
+            }
+
+            return Value.Equals(other);
         }
     }
 }

--- a/azure-proto-core/Resources/Location.cs
+++ b/azure-proto-core/Resources/Location.cs
@@ -1,28 +1,69 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// TODO: follow the full guidelines for these immutable types (IComparable, IEquatable, operator overloads, etc.)
+    ///     TODO: follow the full guidelines for these immutable types (IComparable, IEquatable, operator overloads, etc.)
     /// </summary>
     public class Location : IEquatable<Location>, IEquatable<string>, IComparable<Location>, IComparable<string>
     {
-        public static ref readonly Location Default => ref WestUS;
-        public static readonly Location WestUS = new Location { Name = "WestUS", CanonicalName = "west-us", DisplayName = "West US"};
-        public string Name { get; internal set; }
-        public string CanonicalName { get; internal set; }
-        public string DisplayName { get; internal set; }
-
-        internal Location()
-        {
-        }
+        public static readonly Location WestUS = new Location
+            { Name = "WestUS", CanonicalName = "west-us", DisplayName = "West US" };
 
         public Location(string location)
         {
             Name = GetDefaultName(location);
             CanonicalName = GetCanonicalName(location);
             DisplayName = GetDisplayName(location);
+        }
+
+        internal Location()
+        {
+        }
+
+        public static ref readonly Location Default => ref WestUS;
+
+        public string Name { get; internal set; }
+
+        public string CanonicalName { get; internal set; }
+
+        public string DisplayName { get; internal set; }
+
+        /// <summary>
+        /// </summary>
+        /// <param name="other"></param>
+        public static implicit operator string(Location other)
+        {
+            return other.DisplayName;
+        }
+
+        public static implicit operator Location(string other)
+        {
+            return new Location(other);
+        }
+
+        /// <inheritdoc cref="IComparable{Location}" />
+        public int CompareTo(Location other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return 1;
+            }
+
+            return string.Compare(Name, other.Name);
+        }
+
+        public int CompareTo(string other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return 1;
+            }
+
+            return Name.CompareTo(other);
         }
 
         public bool Equals(Location other)
@@ -40,43 +81,19 @@ namespace azure_proto_core
             return DisplayName;
         }
 
-        static string GetCanonicalName( string name)
+        private static string GetCanonicalName(string name)
         {
             return name;
         }
 
-        static string GetDisplayName( string name)
+        private static string GetDisplayName(string name)
         {
             return name;
         }
 
-        static string GetDefaultName(string name)
+        private static string GetDefaultName(string name)
         {
             return name;
         }
-
-        public int CompareTo(Location other)
-        {
-            if (ReferenceEquals(other,null))
-            {
-                return 1;
-            }
-            return Name.CompareTo(other.Name);
-        }
-
-        public int CompareTo(string other)
-        {
-            if (ReferenceEquals(other,null))
-            {
-                return 1;
-            }
-            return Name.CompareTo(other);
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="other"></param>
-        public static implicit operator string(Location other) => other.DisplayName;
-        public static implicit operator Location(string other) => new Location( other);
     }
 }

--- a/azure-proto-core/Resources/Plan.cs
+++ b/azure-proto-core/Resources/Plan.cs
@@ -1,63 +1,144 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Representation of a publisher plan for marketplace RPs.
+    ///     Representation of a publisher plan for marketplace RPs.
     /// </summary>
     public class Plan : IEquatable<Plan>, IComparable<Plan>
     {
         public string Name { get; set; }
+
         public string Publisher { get; set; }
+
         public string Product { get; set; }
+
         public string PromotionCode { get; set; }
+
         public string Version { get; set; }
 
         public int CompareTo(Plan other)
         {
-            if (other == null) return 1;
-            if (this.Name == null && other.Name != null) return -1;
-            if (this.Name != null)
+            if (other == null)
             {
-                int compareNameResult = this.Name.CompareTo(other.Name);
-                if (compareNameResult != 0) return compareNameResult;
+                return 1;
             }
-            if (this.Product == null && other.Product != null) return -1;
-            if (this.Product != null)
+
+            if (Name == null && other.Name != null)
             {
-                int compareProductResult = this.Product.CompareTo(other.Product);
-                if (compareProductResult != 0) return compareProductResult;
+                return -1;
             }
-            if (this.PromotionCode == null && other.PromotionCode != null) return -1;
-            if (this.PromotionCode != null)
+
+            if (Name != null)
             {
-                int comparePromotionCodeResult = this.PromotionCode.CompareTo(other.PromotionCode);
-                if (comparePromotionCodeResult != 0) return comparePromotionCodeResult;
+                var compareNameResult = Name.CompareTo(other.Name);
+
+                if (compareNameResult != 0)
+                {
+                    return compareNameResult;
+                }
             }
-            if (this.Publisher == null && other.Publisher != null) return -1;
-            if (this.Publisher != null)
+
+            if (Product == null && other.Product != null)
             {
-                int comparePublisherResult = this.Publisher.CompareTo(other.Publisher);
-                if (comparePublisherResult != 0) return comparePublisherResult;
+                return -1;
             }
-            if (this.Version == null && other.Version != null) return -1;
-            if (this.Version != null)
+
+            if (Product != null)
             {
-                int compareVersionResult = this.Version.CompareTo(other.Version);
-                if (compareVersionResult != 0) return compareVersionResult;
+                var compareProductResult = Product.CompareTo(other.Product);
+
+                if (compareProductResult != 0)
+                {
+                    return compareProductResult;
+                }
             }
+
+            if (PromotionCode == null && other.PromotionCode != null)
+            {
+                return -1;
+            }
+
+            if (PromotionCode != null)
+            {
+                var comparePromotionCodeResult = PromotionCode.CompareTo(other.PromotionCode);
+
+                if (comparePromotionCodeResult != 0)
+                {
+                    return comparePromotionCodeResult;
+                }
+            }
+
+            if (Publisher == null && other.Publisher != null)
+            {
+                return -1;
+            }
+
+            if (Publisher != null)
+            {
+                var comparePublisherResult = Publisher.CompareTo(other.Publisher);
+
+                if (comparePublisherResult != 0)
+                {
+                    return comparePublisherResult;
+                }
+            }
+
+            if (Version == null && other.Version != null)
+            {
+                return -1;
+            }
+
+            if (Version != null)
+            {
+                var compareVersionResult = Version.CompareTo(other.Version);
+
+                if (compareVersionResult != 0)
+                {
+                    return compareVersionResult;
+                }
+            }
+
             return 0;
         }
 
         public bool Equals(Plan other)
         {
-            if (other == null) return false;
-            if (this.Name == null && other.Name != null || this.Name != null && !this.Name.Equals(other.Name)) return false;
-            if (this.Product == null && other.Product != null || this.Product != null && !this.Product.Equals(other.Product)) return false;
-            if (this.PromotionCode == null && other.PromotionCode != null || this.PromotionCode != null && !this.PromotionCode.Equals(other.PromotionCode)) return false;
-            if (this.Publisher == null && other.Publisher != null || this.Publisher != null && !this.Publisher.Equals(other.Publisher)) return false;
-            if (this.Version == null && other.Version != null || this.Version != null && !this.Version.Equals(other.Version)) return false;
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Name == null && other.Name != null || Name != null && !Name.Equals(other.Name))
+            {
+                return false;
+            }
+
+            if (Product == null && other.Product != null || Product != null && !Product.Equals(other.Product))
+            {
+                return false;
+            }
+
+            if (PromotionCode == null && other.PromotionCode != null ||
+                PromotionCode != null && !PromotionCode.Equals(other.PromotionCode))
+            {
+                return false;
+            }
+
+            if (Publisher == null && other.Publisher != null ||
+                Publisher != null && !Publisher.Equals(other.Publisher))
+            {
+                return false;
+            }
+
+            if (Version == null && other.Version != null || Version != null && !Version.Equals(other.Version))
+            {
+                return false;
+            }
+
             return true;
         }
     }

--- a/azure-proto-core/Resources/Resource.cs
+++ b/azure-proto-core/Resources/Resource.cs
@@ -1,14 +1,19 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Base resource type: All resources have these properties. Proxy and other untracked resources should extend this class
-    /// TODO: Implement comparison, equality, and type coercion operator overloads
-    /// TODO: What to do with properties derived from ResourceId when object is created? Should we have a special factory for each?
+    ///     Base resource type: All resources have these properties. Proxy and other untracked resources should extend this
+    ///     class
+    ///     TODO: Implement comparison, equality, and type coercion operator overloads
+    ///     TODO: What to do with properties derived from ResourceId when object is created? Should we have a special factory
+    ///     for each?
     /// </summary>
-    public abstract class Resource : IEquatable<Resource>, IEquatable<string>, IComparable<Resource>, IComparable<string>
+    public abstract class Resource : IEquatable<Resource>, IEquatable<string>, IComparable<Resource>,
+        IComparable<string>
     {
         public abstract ResourceIdentifier Id { get; protected set; }
 
@@ -34,7 +39,7 @@ namespace azure_proto_core
                 return false;
             }
 
-            return (Id.Equals(other?.Id));
+            return Id.Equals(other?.Id);
         }
 
         public virtual bool Equals(string other)
@@ -44,7 +49,7 @@ namespace azure_proto_core
                 return false;
             }
 
-            return (Id.Equals(other));
+            return Id.Equals(other);
         }
     }
 }

--- a/azure-proto-core/Resources/ResourceIdentifier.cs
+++ b/azure-proto-core/Resources/ResourceIdentifier.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -6,90 +9,124 @@ using System.Linq;
 namespace azure_proto_core
 {
     /// <summary>
-    /// Canonical Representation of a Resource Identity
-    /// TODO: Implement operator overloads for equality, comparison, and coercion
+    ///     Canonical Representation of a Resource Identity
+    ///     TODO: Implement operator overloads for equality, comparison, and coercion
     /// </summary>
-    public class ResourceIdentifier : IEquatable<ResourceIdentifier>, IEquatable<string>, IComparable<string>, IComparable<ResourceIdentifier>
+    public class ResourceIdentifier : IEquatable<ResourceIdentifier>, IEquatable<string>, IComparable<string>,
+        IComparable<ResourceIdentifier>
     {
-        public static class KnownKeys
-        {
-            public static string Subscription => "subscriptions";
-            public static string Tenant => "tenants";
-            public static string ResourceGroup => "resourcegroups";
-            public static string Location => "locations";
-            public static string ProviderNamespace => "providers";
-            public static string UntrackedSubResource => Guid.NewGuid().ToString();
-        }
-
-        IDictionary<string, string> _partsDictionary = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        private readonly IDictionary<string, string> _partsDictionary =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         public ResourceIdentifier(string id)
         {
             Id = id;
+
             //TODO: Due to the implicit this is called for blank constructions such as new PhResourceGroup
             if (id != null)
+            {
                 Parse(id);
+            }
         }
 
         public string Id { get; protected set; }
+
         public string Name { get; protected set; }
+
         public ResourceType Type { get; protected set; }
 
-        public string Subscription => _partsDictionary.ContainsKey(KnownKeys.Subscription) ? _partsDictionary[KnownKeys.Subscription] : null;
+        public string Subscription => _partsDictionary.ContainsKey(KnownKeys.Subscription)
+            ? _partsDictionary[KnownKeys.Subscription]
+            : null;
 
-        public string ResourceGroup => _partsDictionary.ContainsKey(KnownKeys.ResourceGroup) ? _partsDictionary[KnownKeys.ResourceGroup] : null;
+        public string ResourceGroup => _partsDictionary.ContainsKey(KnownKeys.ResourceGroup)
+            ? _partsDictionary[KnownKeys.ResourceGroup]
+            : null;
 
         /// <summary>
-        /// Currently this will contain the identifier for either the parent resource, the resource group, the location, the subscription, 
-        /// or the tenant that is the logical parent of this resource
+        ///     Currently this will contain the identifier for either the parent resource, the resource group, the location, the
+        ///     subscription,
+        ///     or the tenant that is the logical parent of this resource
         /// </summary>
         public ResourceIdentifier Parent { get; protected set; }
 
+        public virtual int CompareTo(ResourceIdentifier other)
+        {
+            return string.Compare(
+                Id?.ToLowerInvariant(),
+                other?.Id?.ToLowerInvariant(),
+                StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public virtual int CompareTo(string other)
+        {
+            return string.Compare(
+                Id?.ToLowerInvariant(),
+                other?.ToLowerInvariant(),
+                StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public virtual bool Equals(ResourceIdentifier other)
+        {
+            return string.Equals(
+                Id?.ToLowerInvariant(),
+                other?.Id?.ToLowerInvariant(),
+                StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public virtual bool Equals(string other)
+        {
+            return string.Equals(
+                Id?.ToLowerInvariant(),
+                other?.ToLowerInvariant(),
+                StringComparison.InvariantCultureIgnoreCase);
+        }
+
         /// <summary>
-        /// Allow static, safe comparisons of resource identifier strings or objects
+        ///     Allow static, safe comparisons of resource identifier strings or objects
         /// </summary>
         /// <param name="x">A resource id</param>
         /// <param name="y">A resource id</param>
         /// <returns>true if the resource ids are equivalent, otherwise false</returns>
         public static bool Equals(ResourceIdentifier x, ResourceIdentifier y)
         {
-            if (null == x && null == y) return true;
-            if (null == x || null == y) return false;
+            if (null == x && null == y)
+            {
+                return true;
+            }
+
+            if (null == x || null == y)
+            {
+                return false;
+            }
+
             return x.Equals(y);
         }
 
         /// <summary>
-        /// Allow static null-safe comparisons between resource identifier strings or objects
+        ///     Allow static null-safe comparisons between resource identifier strings or objects
         /// </summary>
         /// <param name="x">A resource id</param>
         /// <param name="y">A resource id</param>
         /// <returns>-1 if x &lt; y, 0 if x == y, 1 if x &gt; y</returns>
         public static int CompareTo(ResourceIdentifier x, ResourceIdentifier y)
         {
-            if (null == x && null == y) return 0;
-            if (null == x) return -1;
-            if (null == y) return 1;
+            if (null == x && null == y)
+            {
+                return 0;
+            }
+
+            if (null == x)
+            {
+                return -1;
+            }
+
+            if (null == y)
+            {
+                return 1;
+            }
+
             return x.CompareTo(y);
-        }
-
-        public virtual int CompareTo(string other)
-        {
-            return string.Compare(Id?.ToLowerInvariant(), other?.ToLowerInvariant(), StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        public virtual int CompareTo(ResourceIdentifier other)
-        {
-            return string.Compare(Id?.ToLowerInvariant(), other?.Id?.ToLowerInvariant(), StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        public virtual bool Equals(ResourceIdentifier other)
-        {
-            return string.Equals(Id?.ToLowerInvariant(), other?.Id?.ToLowerInvariant(), StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        public virtual bool Equals(string other)
-        {
-            return string.Equals(Id?.ToLowerInvariant(), other?.ToLowerInvariant(), StringComparison.InvariantCultureIgnoreCase);
         }
 
         public override string ToString()
@@ -98,7 +135,7 @@ namespace azure_proto_core
         }
 
         /// <summary>
-        /// Populate Resource Identity fields from input string
+        ///     Populate Resource Identity fields from input string
         /// </summary>
         /// <param name="id">A properly formed resource identity</param>
         protected virtual void Parse(string id)
@@ -110,7 +147,8 @@ namespace azure_proto_core
             }
 
             // Resource ID paths consist mainly of name/value pairs. Split the uri so we have an array of name/value pairs
-            var parts = id.Split(new char[] {'/'}, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var parts = id.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+
             // There must be at least one name/value pair for the resource id to be valid
             if (parts.Count < 2)
             {
@@ -119,16 +157,16 @@ namespace azure_proto_core
 
             //This is asserting that resources must start with '/subscriptions', /tenants, or /locations.
             //TODO: we will need to update this code to accomodate tenant based resources (which start with /providers)
-            if (!(KnownKeys.Subscription.Equals(parts[0], StringComparison.InvariantCultureIgnoreCase)
-               || KnownKeys.Tenant.Equals(parts[0], StringComparison.InvariantCultureIgnoreCase)
-               || KnownKeys.Location.Equals(parts[0], StringComparison.InvariantCultureIgnoreCase)))
+            if (!(KnownKeys.Subscription.Equals(parts[0], StringComparison.InvariantCultureIgnoreCase) ||
+                  KnownKeys.Tenant.Equals(parts[0], StringComparison.InvariantCultureIgnoreCase) ||
+                  KnownKeys.Location.Equals(parts[0], StringComparison.InvariantCultureIgnoreCase)))
             {
                 throw new ArgumentOutOfRangeException($"'{id}' is not a valid resource");
             }
 
             Type = new ResourceType(id);
 
-            // In the case that this resource is a singleton proxy resource, the number of parts will be odd, 
+            // In the case that this resource is a singleton proxy resource, the number of parts will be odd,
             // where the last part is the type name of the singleton
             if (parts.Count % 2 != 0)
             {
@@ -136,7 +174,7 @@ namespace azure_proto_core
                 parts.RemoveAt(parts.Count - 1);
             }
 
-            // This spplits into resource that come from a provider (which have the providers keyword) and 
+            // This spplits into resource that come from a provider (which have the providers keyword) and
             // resources that are built in to ARM (e.g. /subscriptions/{sub}, /subscriptions/{sub}/resourceGroups/{rg})
             // TODO: This code will need to be updates for extension resources, which have two providers
             if (id.ToLowerInvariant().Contains("providers"))
@@ -153,17 +191,19 @@ namespace azure_proto_core
         {
             Debug.Assert(parts != null);
             Debug.Assert(parts.Count > 1);
+
             // The resource consists of well-known name-value pairs.  Make a resource dictionary
             // using the names as keys, and the values as values
-            for(int i = 0; i < parts.Count - 1; i += 2)
+            for (var i = 0; i < parts.Count - 1; i += 2)
             {
                 _partsDictionary.Add(parts[i], parts[i + 1]);
             }
 
             // resource name is always the last part
             Name = parts.Last();
-            parts.RemoveAt(parts.Count-1);
-            parts.RemoveAt(parts.Count-1);
+            parts.RemoveAt(parts.Count - 1);
+            parts.RemoveAt(parts.Count - 1);
+
             // remove the last key/value pair to arrive at the parent (Count will be zero for /subscriptions/{foo})
             Parent = parts.Count > 1 ? new ResourceIdentifier($"/{string.Join("/", parts)}") : null;
         }
@@ -171,30 +211,54 @@ namespace azure_proto_core
         protected virtual void ParseProviderResource(IList<string> parts)
         {
             // The resource consists of name/value pairs, make a dictionary out of it
-            for (int i = 0; i < parts.Count - 1; i += 2)
+            for (var i = 0; i < parts.Count - 1; i += 2)
             {
                 _partsDictionary.Add(parts[i], parts[i + 1]);
             }
 
             Name = parts.Last();
-            parts.RemoveAt(parts.Count-1);
+            parts.RemoveAt(parts.Count - 1);
+
             // remove the type name (there will be no typename if this is a singleton sub resource)
             if (parts.Count % 2 == 1)
             {
-                parts.RemoveAt(parts.Count-1);
+                parts.RemoveAt(parts.Count - 1);
             }
+
             //If this is a top-level resource, remove the providers/Namespace pair, otherwise continue
             if (parts.Count > 2 && string.Equals(parts[parts.Count - 2], KnownKeys.ProviderNamespace))
             {
-                parts.RemoveAt(parts.Count-1);
-                parts.RemoveAt(parts.Count-1);
+                parts.RemoveAt(parts.Count - 1);
+                parts.RemoveAt(parts.Count - 1);
             }
 
             //If this is not a top-level resource, it will have a parent
             Parent = parts.Count > 1 ? new ResourceIdentifier($"/{string.Join("/", parts)}") : null;
         }
 
-        public static implicit operator string(ResourceIdentifier other) => other.Id;
-        public static implicit operator ResourceIdentifier(string other) => new ResourceIdentifier( other);
+        public static implicit operator string(ResourceIdentifier other)
+        {
+            return other.Id;
+        }
+
+        public static implicit operator ResourceIdentifier(string other)
+        {
+            return new ResourceIdentifier(other);
+        }
+
+        public static class KnownKeys
+        {
+            public static string Subscription => "subscriptions";
+
+            public static string Tenant => "tenants";
+
+            public static string ResourceGroup => "resourcegroups";
+
+            public static string Location => "locations";
+
+            public static string ProviderNamespace => "providers";
+
+            public static string UntrackedSubResource => Guid.NewGuid().ToString();
+        }
     }
 }

--- a/azure-proto-core/Resources/ResourceType.cs
+++ b/azure-proto-core/Resources/ResourceType.cs
@@ -1,46 +1,80 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Structure respresenting a resource type
-    /// TODO: Fill in comparison methods and comparison, equality, and coercion operator overloads
+    ///     Structure respresenting a resource type
+    ///     TODO: Fill in comparison methods and comparison, equality, and coercion operator overloads
     /// </summary>
-    public class ResourceType : IEquatable<ResourceType>, IEquatable<string>, IComparable<ResourceType>, IComparable<string>
+    public class ResourceType : IEquatable<ResourceType>, IEquatable<string>, IComparable<ResourceType>,
+        IComparable<string>
     {
         /// <summary>
-        /// The "none" resource type
+        ///     The "none" resource type
         /// </summary>
         public static readonly ResourceType None = new ResourceType { Namespace = string.Empty, Type = string.Empty };
 
         private ResourceType()
         {
         }
+
         public ResourceType(string resourceIdOrType)
         {
             Parse(resourceIdOrType);
         }
+
         public string Namespace { get; private set; }
+
         public string Type { get; private set; }
 
-        public ResourceType Parent 
-        { 
+        public ResourceType Parent
+        {
             get
             {
-                var parts = Type.Split(new char[] {'/'}, StringSplitOptions.RemoveEmptyEntries);
-                if (parts.Length < 2) return ResourceType.None;
+                var parts = Type.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+                if (parts.Length < 2)
+                {
+                    return None;
+                }
+
                 var list = new List<string>(parts);
                 list.RemoveAt(list.Count - 1);
+
                 return new ResourceType($"{Namespace}/{string.Join("/", list.ToArray())}");
-            } 
+            }
+        }
+
+        public int CompareTo(ResourceType other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(string other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Equals(ResourceType other)
+        {
+            return string.Equals(ToString(), other.ToString(), StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public bool Equals(string other)
+        {
+            return string.Equals(ToString(), other, StringComparison.InvariantCultureIgnoreCase);
         }
 
         internal void Parse(string resourceIdOrType)
         {
             // Note that this code will either parse a resource id to find the type, or a resource type
             resourceIdOrType = resourceIdOrType?.Trim('/');
+
             // exclude null or empty strings
             if (string.IsNullOrWhiteSpace(resourceIdOrType))
             {
@@ -48,12 +82,14 @@ namespace azure_proto_core
             }
 
             // split the path into segments
-            var parts = resourceIdOrType.Split(new char[] {'/'}, StringSplitOptions.RemoveEmptyEntries).ToList();
+            var parts = resourceIdOrType.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries).ToList();
+
             // There must be at least a namespace and type name
             if (parts.Count < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(resourceIdOrType));
             }
+
             // if the type is just subscriptions, it is a built-in type in the Microsoft.Resources namespace
             if (parts.Count == 1)
             {
@@ -61,22 +97,24 @@ namespace azure_proto_core
                 Type = parts[0];
                 Namespace = "Microsoft.Resources";
             }
+
             //Handle resource identifiers from RPs (they have the /providers path segment)
             if (parts.Contains(ResourceIdentifier.KnownKeys.ProviderNamespace))
             {
                 // it is a resource id from a provider
                 var index = parts.IndexOf(ResourceIdentifier.KnownKeys.ProviderNamespace);
-                for (int i = index; i >= 0; --i)
+                for (var i = index; i >= 0; --i)
                 {
                     parts.RemoveAt(i);
                 }
+
                 if (parts.Count < 3)
                 {
                     throw new ArgumentOutOfRangeException(nameof(resourceIdOrType), "Invalid resource id.");
                 }
 
                 var type = new List<string>();
-                for (int i = 1; i < parts.Count; i+= 2)
+                for (var i = 1; i < parts.Count; i += 2)
                 {
                     type.Add(parts[i]);
                 }
@@ -84,6 +122,7 @@ namespace azure_proto_core
                 Namespace = parts[0];
                 Type = string.Join("/", type);
             }
+
             // Handle resource types (Micsrsoft.Compute/virtualMachines, Microsoft.Network/virtualNetworks/subnets)
             else if (parts[0].Contains('.'))
             {
@@ -91,8 +130,9 @@ namespace azure_proto_core
                 Namespace = parts[0];
                 Type = string.Join("/", parts.Skip(Math.Max(0, 1)).Take(parts.Count() - 1));
             }
+
             // Handle built-in resource ids (e.g. /subscriptions/{sub}, /subscriptions/{sub}/resourceGroups/{rg})
-            else if (parts.Count %2 == 0)
+            else if (parts.Count % 2 == 0)
             {
                 // primitive resource manager resource id
                 Namespace = "Microsoft.Resources";
@@ -109,32 +149,27 @@ namespace azure_proto_core
             return $"{Namespace}/{Type}";
         }
 
-        public bool Equals(ResourceType other)
-        {
-            return string.Equals(this.ToString(), other.ToString(), StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        public bool Equals(string other)
-        {
-            return string.Equals(this.ToString(), other, StringComparison.InvariantCultureIgnoreCase);
-        }
-
-        public int CompareTo(ResourceType other)
-        {
-            throw new NotImplementedException();
-        }
-
-        public int CompareTo(string other)
-        {
-            throw new NotImplementedException();
-        }
         public override bool Equals(object obj)
         {
-            if (obj == null) return false;
+            if (obj == null)
+            {
+                return false;
+            }
+
             var resourceObj = obj as ResourceType;
-            if (resourceObj != null) return Equals(resourceObj);
+
+            if (resourceObj != null)
+            {
+                return Equals(resourceObj);
+            }
+
             var stringObj = obj as string;
-            if (stringObj != null) return Equals(stringObj);
+
+            if (stringObj != null)
+            {
+                return Equals(stringObj);
+            }
+
             return base.Equals(obj);
         }
 
@@ -143,12 +178,39 @@ namespace azure_proto_core
             return ToString().GetHashCode();
         }
 
-        public static implicit operator ResourceType(string other) => new ResourceType(other);
-        public static bool operator ==(ResourceType source, string target) => source.Equals(target);
-        public static bool operator ==(string source, ResourceType target) => target.Equals(source);
-        public static bool operator ==(ResourceType source, ResourceType target) => source.Equals(target);
-        public static bool operator !=(ResourceType source, string target) => !source.Equals(target);
-        public static bool operator !=(string source, ResourceType target) => !target.Equals(source);
-        public static bool operator !=(ResourceType source, ResourceType target) => !source.Equals(target);
+        public static implicit operator ResourceType(string other)
+        {
+            return new ResourceType(other);
+        }
+
+        public static bool operator ==(ResourceType source, string target)
+        {
+            return source.Equals(target);
+        }
+
+        public static bool operator ==(string source, ResourceType target)
+        {
+            return target.Equals(source);
+        }
+
+        public static bool operator ==(ResourceType source, ResourceType target)
+        {
+            return source.Equals(target);
+        }
+
+        public static bool operator !=(ResourceType source, string target)
+        {
+            return !source.Equals(target);
+        }
+
+        public static bool operator !=(string source, ResourceType target)
+        {
+            return !target.Equals(source);
+        }
+
+        public static bool operator !=(ResourceType source, ResourceType target)
+        {
+            return !source.Equals(target);
+        }
     }
 }

--- a/azure-proto-core/Resources/Sku.cs
+++ b/azure-proto-core/Resources/Sku.cs
@@ -1,60 +1,143 @@
-﻿using System;
-using System.Diagnostics.CodeAnalysis;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Representaion of ARM SKU
+    ///     Representaion of ARM SKU
     /// </summary>
     public class Sku : IEquatable<Sku>, IComparable<Sku>
     {
         public string Name { get; set; }
+
         public string Tier { get; set; }
+
         public string Family { get; set; }
+
         public string Size { get; set; }
+
         public long? Capacity { get; set; }
 
         public int CompareTo(Sku other)
         {
-            if (other == null) return 1;
-            if (this.Name == null && other.Name != null) return -1;
-            if (this.Name != null)
+            if (other == null)
             {
-                int compareNameResult = this.Name.CompareTo(other.Name);
-                if (compareNameResult != 0) return compareNameResult;
+                return 1;
             }
-            if (this.Family == null && other.Family != null) return -1;
-            if (this.Family != null)
+
+            if (Name == null && other.Name != null)
             {
-                int compareFamilyResult = this.Family.CompareTo(other.Family);
-                if (compareFamilyResult != 0) return compareFamilyResult;
+                return -1;
             }
-            if (this.Size == null && other.Size != null) return -1;
-            if (this.Size != null)
+
+            if (Name != null)
             {
-                int compareSizeResult = this.Size.CompareTo(other.Size);
-                if (compareSizeResult != 0) return compareSizeResult;
+                var compareNameResult = Name.CompareTo(other.Name);
+
+                if (compareNameResult != 0)
+                {
+                    return compareNameResult;
+                }
             }
-            if (this.Tier == null && other.Tier != null) return -1;
-            if (this.Tier != null)
+
+            if (Family == null && other.Family != null)
             {
-                int compareTierResult = this.Tier.CompareTo(other.Tier);
-                if (compareTierResult != 0) return compareTierResult;
+                return -1;
             }
-            if (this.Capacity == null && other.Capacity == null) return 0;
-            if (this.Capacity == null) return -1;
-            if (other.Capacity == null) return 1;
-            return this.Capacity.Value.CompareTo(other.Capacity.Value);
+
+            if (Family != null)
+            {
+                var compareFamilyResult = Family.CompareTo(other.Family);
+
+                if (compareFamilyResult != 0)
+                {
+                    return compareFamilyResult;
+                }
+            }
+
+            if (Size == null && other.Size != null)
+            {
+                return -1;
+            }
+
+            if (Size != null)
+            {
+                var compareSizeResult = Size.CompareTo(other.Size);
+
+                if (compareSizeResult != 0)
+                {
+                    return compareSizeResult;
+                }
+            }
+
+            if (Tier == null && other.Tier != null)
+            {
+                return -1;
+            }
+
+            if (Tier != null)
+            {
+                var compareTierResult = Tier.CompareTo(other.Tier);
+
+                if (compareTierResult != 0)
+                {
+                    return compareTierResult;
+                }
+            }
+
+            if (Capacity == null && other.Capacity == null)
+            {
+                return 0;
+            }
+
+            if (Capacity == null)
+            {
+                return -1;
+            }
+
+            if (other.Capacity == null)
+            {
+                return 1;
+            }
+
+            return Capacity.Value.CompareTo(other.Capacity.Value);
         }
 
         public bool Equals(Sku other)
         {
-            if (other == null) return false;
-            if (this.Name == null && other.Name != null || this.Name != null && !this.Name.Equals(other.Name)) return false;
-            if (this.Family == null && other.Family != null || this.Family != null && !this.Family.Equals(other.Family)) return false;
-            if (this.Size == null && other.Size != null || this.Size != null && !this.Size.Equals(other.Size)) return false;
-            if (this.Tier == null && other.Tier != null || this.Tier != null && !this.Tier.Equals(other.Tier)) return false;
-            if (this.Capacity == null && other.Capacity != null || this.Capacity != null && !this.Capacity.Equals(other.Capacity)) return false;
+            if (other == null)
+            {
+                return false;
+            }
+
+            if (Name == null && other.Name != null || Name != null && !Name.Equals(other.Name))
+            {
+                return false;
+            }
+
+            if (Family == null && other.Family != null || Family != null && !Family.Equals(other.Family))
+            {
+                return false;
+            }
+
+            if (Size == null && other.Size != null || Size != null && !Size.Equals(other.Size))
+            {
+                return false;
+            }
+
+            if (Tier == null && other.Tier != null || Tier != null && !Tier.Equals(other.Tier))
+            {
+                return false;
+            }
+
+            if (Capacity == null && other.Capacity != null ||
+                Capacity != null && !Capacity.Equals(other.Capacity))
+            {
+                return false;
+            }
+
             return true;
         }
     }

--- a/azure-proto-core/Resources/TrackedResource.cs
+++ b/azure-proto-core/Resources/TrackedResource.cs
@@ -1,17 +1,21 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Collections.Generic;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Generic representation of a tracked resource.  All tracked resources should extend this class
+    ///     Generic representation of a tracked resource.  All tracked resources should extend this class
     /// </summary>
-    public abstract class TrackedResource: Resource
+    public abstract class TrackedResource : Resource
     {
-        public virtual IDictionary<string, string> Tags => new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
+        public virtual IDictionary<string, string> Tags =>
+            new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase);
 
         public virtual Location Location { get; protected set; }
-        
+
         public override ResourceIdentifier Id { get; protected set; }
     }
 }

--- a/azure-proto-core/SubscriptionOperations.cs
+++ b/azure-proto-core/SubscriptionOperations.cs
@@ -1,35 +1,54 @@
-﻿using Azure;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using Azure;
 using Azure.ResourceManager.Resources;
 using Azure.ResourceManager.Resources.Models;
 using azure_proto_core.Adapters;
-using System;
-using System.Threading;
 
 namespace azure_proto_core
 {
     /// <summary>
-    /// Subscription operations
+    ///     Subscription operations
     /// </summary>
     public class SubscriptionOperations : OperationsBase
     {
         public static readonly string AzureResourceType = "Microsoft.Resources/subscriptions";
 
-        public SubscriptionOperations(ArmClientContext context, string defaultSubscription) : base(context, $"/subscriptions/{defaultSubscription}") { }
+        public SubscriptionOperations(ArmClientContext context, string defaultSubscription)
+            : base(context, $"/subscriptions/{defaultSubscription}")
+        {
+        }
 
-        public SubscriptionOperations(ArmClientContext context, ResourceIdentifier id) : base(context, id) { }
+        public SubscriptionOperations(ArmClientContext context, ResourceIdentifier id)
+            : base(context, id)
+        {
+        }
 
-        public SubscriptionOperations(ArmClientContext context, Resource subscription) : base(context, subscription) { }
+        public SubscriptionOperations(ArmClientContext context, Resource subscription)
+            : base(context, subscription)
+        {
+        }
 
         public override ResourceType ResourceType => AzureResourceType;
 
-        public Pageable<ResourceGroupOperations> ListResourceGroups(CancellationToken cancellationToken = default(CancellationToken))
+        internal SubscriptionsOperations SubscriptionsClient =>
+            GetClient((uri, cred) => new ResourcesManagementClient(uri, Guid.NewGuid().ToString(), cred)).Subscriptions;
+
+        internal ResourceGroupsOperations RgOperations =>
+            GetClient((uri, cred) => new ResourcesManagementClient(uri, Id.Subscription, cred)).ResourceGroups;
+
+        public Pageable<ResourceGroupOperations> ListResourceGroups(CancellationToken cancellationToken = default)
         {
             return new PhWrappingPageable<ResourceGroup, ResourceGroupOperations>(
                 RgOperations.List(null, null, cancellationToken),
                 s => new ResourceGroupOperations(ClientContext, new PhResourceGroup(s)));
         }
 
-        public AsyncPageable<ResourceGroupOperations> ListResourceGroupsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public AsyncPageable<ResourceGroupOperations> ListResourceGroupsAsync(
+            CancellationToken cancellationToken = default)
         {
             return new PhWrappingAsyncPageable<ResourceGroup, ResourceGroupOperations>(
                 RgOperations.ListAsync(null, null, cancellationToken),
@@ -53,11 +72,7 @@ namespace azure_proto_core
 
         public ResourceGroupContainerOperations ResourceGroups()
         {
-            return new ResourceGroupContainerOperations(this.ClientContext, this);
+            return new ResourceGroupContainerOperations(ClientContext, this);
         }
-
-        internal SubscriptionsOperations SubscriptionsClient => GetClient<ResourcesManagementClient>((uri, cred) => new ResourcesManagementClient(uri, Guid.NewGuid().ToString(), cred)).Subscriptions;
-
-        internal ResourceGroupsOperations RgOperations => GetClient<ResourcesManagementClient>((uri, cred) => new ResourcesManagementClient(uri, Id.Subscription, cred)).ResourceGroups;
     }
 }

--- a/azure-proto-core/TagableResourceOperations.cs
+++ b/azure-proto-core/TagableResourceOperations.cs
@@ -1,13 +1,20 @@
-﻿using System.Threading;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace azure_proto_core
 {
     public interface ITaggable<TOperations, TResource>
-        where TResource:Resource 
-        where TOperations: ITaggable<TOperations, TResource>
+        where TResource : Resource
+        where TOperations : ITaggable<TOperations, TResource>
     {
         ArmOperation<TOperations> AddTag(string key, string value);
-        Task<ArmOperation<TOperations>> AddTagAsync(string key, string value, CancellationToken cancellationToken = default);
+
+        Task<ArmOperation<TOperations>> AddTagAsync(
+            string key,
+            string value,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/azure-proto-core/XResourceGroup.cs
+++ b/azure-proto-core/XResourceGroup.cs
@@ -1,16 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 namespace azure_proto_core
 {
     public class XResourceGroup : ResourceGroupOperations
     {
-        public XResourceGroup(ArmClientContext context, PhResourceGroup resource): base(context, resource)
+        public XResourceGroup(ArmClientContext context, PhResourceGroup resource)
+            : base(context, resource)
         {
             Model = resource;
         }
 
-        public PhResourceGroup Model { get; private set; }
+        public PhResourceGroup Model { get; }
     }
 }

--- a/azure-proto-core/azure-proto-core.csproj
+++ b/azure-proto-core/azure-proto-core.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>azure_proto_core</RootNamespace>
     <LangVersion>latest</LangVersion>
-    <CodeAnalysisRuleSet>..\StyleCopDefault.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\stylecop.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>obj\docs.xml</DocumentationFile>	
   </PropertyGroup>
 

--- a/styleCop.ruleset
+++ b/styleCop.ruleset
@@ -67,7 +67,7 @@
         <Rule Id="SA1128"  Action="Warning" />          <!-- Put constructor initializers on their own line -->
         <Rule Id="SA1129"  Action="Warning" />          <!-- Do not use default value type constructor -->
         <Rule Id="SA1130"  Action="Warning" />          <!-- Use lambda syntax -->
-        <Rule Id="SA1131"  Action="Warning" />          <!-- Use readable conditions -->
+        <Rule Id="SA1131"  Action="None" />          <!-- Use readable conditions -->
         <Rule Id="SA1132"  Action="Warning" />          <!-- Do not combine fields -->
         <Rule Id="SA1133"  Action="Warning" />          <!-- Do not combine attributes -->
         <Rule Id="SA1134"  Action="Warning" />          <!-- Attributes should not share line -->
@@ -75,7 +75,7 @@
         <Rule Id="SA1136"  Action="Warning" />          <!-- Enum values should be on separate lines -->
         <Rule Id="SA1137"  Action="Warning" />          <!-- Elements should have the same indentation -->
         <Rule Id="SA1139"  Action="Warning" />          <!-- Use literal suffix notation instead of casting -->
-        <Rule Id="SX1101"  Action="None" />             <!-- Do not prefix local calls with 'this.' -->
+        <Rule Id="SX1101"  Action="Warning" />             <!-- Do not prefix local calls with 'this.' -->
     </Rules>
 	
     <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers.OrderingRules">
@@ -194,13 +194,13 @@
         <Rule Id="SA1630"  Action="None" />             <!-- Documentation text should contain whitespace -->
         <Rule Id="SA1631"  Action="None" />             <!-- Documentation should meet character percentage -->
         <Rule Id="SA1632"  Action="None" />             <!-- Documentation text should meet minimum character length -->
-        <Rule Id="SA1633"  Action="Warning" />          <!-- File should have header -->
+        <Rule Id="SA1633"  Action="None" />          <!-- File should have header -->
         <Rule Id="SA1634"  Action="Warning" />          <!-- File header should show copyright -->
         <Rule Id="SA1635"  Action="Warning" />          <!-- File header should have copyright text -->
         <Rule Id="SA1636"  Action="Warning" />          <!-- File header copyright text should match -->
-        <Rule Id="SA1637"  Action="Warning" />          <!-- File header should contain file name -->
-        <Rule Id="SA1638"  Action="Warning" />          <!-- File header file name documentation should match file name -->
-        <Rule Id="SA1639"  Action="Warning" />          <!-- File header should have summary -->
+        <Rule Id="SA1637"  Action="None" />          <!-- File header should contain file name -->
+        <Rule Id="SA1638"  Action="None" />          <!-- File header file name documentation should match file name -->
+        <Rule Id="SA1639"  Action="None" />          <!-- File header should have summary -->
         <Rule Id="SA1640"  Action="Warning" />          <!-- File header should have valid company text -->
         <Rule Id="SA1641"  Action="Warning" />          <!-- File header company name text should match -->
         <Rule Id="SA1642"  Action="Warning" />          <!-- Constructor summary documentation should begin with standard text -->


### PR DESCRIPTION
Reduced from ~1900 to ~835. Since XML doc is duplicated in CodeAnalysis and StyleCop, we have about 300 mostly doc issues. There are some small number of non-doc issues you can take fix as you encounter them.

Please note that some file has been restructured (methods, members sorted based access). If you have outstanding files, you may want to diff your change and apply to the fixed files.