### PR TITLE
Proposal for naming changes for operations/container extensions

### DIFF
--- a/Azure.ResourceManager.Core/AzureResourceManagerClient.cs
+++ b/Azure.ResourceManager.Core/AzureResourceManagerClient.cs
@@ -128,29 +128,22 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the Azure subscription operations.
         /// </summary>
-        /// <param name="subscription">  The data model of the subscription. </param>
+        /// <param name="subscriptionData">  The data model of the subscription. </param>
         /// <returns> Subscription operations. </returns>
-        public SubscriptionOperations Subscription(SubscriptionData subscription) => new SubscriptionOperations(ClientOptions, subscription);
+        public Subscription GetSubscription(SubscriptionData subscriptionData) => new Subscription(ClientOptions, subscriptionData);
 
         /// <summary>
         /// Gets the Azure subscription operations.
         /// </summary>
-        /// <param name="subscription"> The resource identifier of the subscription. </param>
+        /// <param name="subscriptionId"> The resource identifier of the subscription. </param>
         /// <returns> Subscription operations. </returns>
-        public SubscriptionOperations Subscription(ResourceIdentifier subscription) => new SubscriptionOperations(ClientOptions, subscription);
-
-        /// <summary>
-        /// Gets the Azure subscription operations.
-        /// </summary>
-        /// <param name="subscription"> The id of the subscription. </param>
-        /// <returns> Subscription operations. </returns>
-        public SubscriptionOperations Subscription(string subscription) => new SubscriptionOperations(ClientOptions, subscription);
+        public SubscriptionOperations GetSubscriptionOperations(ResourceIdentifier subscriptionId) => new SubscriptionOperations(ClientOptions, subscriptionId);
 
         /// <summary>
         /// Gets the Azure subscriptions.
         /// </summary>
         /// <returns> Subscription container. </returns>
-        public SubscriptionContainer Subscriptions()
+        public SubscriptionContainer GetSubscriptionContainer()
         {
             return new SubscriptionContainer(ClientOptions);
         }
@@ -275,32 +268,32 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets resource group operations.
         /// </summary>
-        /// <param name="subscription"> The id of the Azure subscription. </param>
-        /// <param name="resourceGroup"> The resource group name. </param>
+        /// <param name="subscriptionGuid"> The id of the Azure subscription. </param>
+        /// <param name="resourceGroupName"> The resource group name. </param>
         /// <returns> Resource group operations. </returns>
-        public ResourceGroupOperations ResourceGroup(string subscription, string resourceGroup)
+        public ResourceGroupOperations GetResourceGroupOperations(string subscriptionGuid, string resourceGroupName)
         {
-            return new ResourceGroupOperations(ClientOptions, $"/subscriptions/{subscription}/resourceGroups/{resourceGroup}");
+            return new ResourceGroupOperations(ClientOptions, $"/subscriptions/{subscriptionGuid}/resourceGroups/{resourceGroupName}");
         }
 
         /// <summary>
         /// Gets resource group operations.
         /// </summary>
-        /// <param name="resourceGroup"> The resource identifier of the resource group. </param>
+        /// <param name="resourceGroupName"> The resource identifier of the resource group. </param>
         /// <returns> Resource group operations. </returns>
-        public ResourceGroupOperations ResourceGroup(ResourceIdentifier resourceGroup)
+        public ResourceGroupOperations GetResourceGroupOperations(ResourceIdentifier resourceGroupName)
         {
-            return new ResourceGroupOperations(ClientOptions, resourceGroup);
+            return new ResourceGroupOperations(ClientOptions, resourceGroupName);
         }
 
         /// <summary>
         /// Gets resource group operations.
         /// </summary>
-        /// <param name="resourceGroup"> The data model of the resource group. </param>
+        /// <param name="resourceGroupName"> The data model of the resource group. </param>
         /// <returns> Resource group operations. </returns>
-        public ResourceGroupOperations ResourceGroup(ResourceGroupData resourceGroup)
+        public ResourceGroup GetResourceGroup(ResourceGroupData resourceGroupData)
         {
-            return new ResourceGroupOperations(ClientOptions, resourceGroup.Id);
+            return new ResourceGroup(ClientOptions, resourceGroupData);
         }
 
         /// <summary>
@@ -385,7 +378,7 @@ namespace Azure.ResourceManager.Core
             string sub = DefaultSubscription?.Id?.Subscription;
             if (null == sub)
             {
-                sub = await Subscriptions().GetDefaultSubscriptionAsync(cancellationToken);
+                sub = await GetSubscriptionContainer().GetDefaultSubscriptionAsync(cancellationToken);
             }
 
             return sub;

--- a/Azure.ResourceManager.Core/SubscriptionOperations.cs
+++ b/Azure.ResourceManager.Core/SubscriptionOperations.cs
@@ -22,16 +22,6 @@ namespace Azure.ResourceManager.Core
         /// Initializes a new instance of the <see cref="SubscriptionOperations"/> class.
         /// </summary>
         /// <param name="options"> The client parameters to use in these operations. </param>
-        /// <param name="subscriptionId"> The Id of the subscription. </param>
-        internal SubscriptionOperations(AzureResourceManagerClientOptions options, string subscriptionId)
-            : base(options, $"/subscriptions/{subscriptionId}")
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SubscriptionOperations"/> class.
-        /// </summary>
-        /// <param name="options"> The client parameters to use in these operations. </param>
         /// <param name="id"> The identifier of the subscription. </param>
         internal SubscriptionOperations(AzureResourceManagerClientOptions options, ResourceIdentifier id)
             : base(options, id)
@@ -63,38 +53,28 @@ namespace Azure.ResourceManager.Core
         /// <summary>
         /// Gets the resource group operations for a given resource group.
         /// </summary>
-        /// <param name="resourceGroup"> The resource group. </param>
+        /// <param name="resourceGroupData"> The resource group. </param>
         /// <returns> The resource group operations. </returns>
-        public ResourceGroupOperations ResourceGroup(ResourceGroupData resourceGroup)
+        public ResourceGroup GetResourceGroup(ResourceGroupData resourceGroupData)
         {
-            return new ResourceGroupOperations(ClientOptions, resourceGroup);
+            return new ResourceGroup(ClientOptions, resourceGroupData);
         }
 
         /// <summary>
         /// Gets the resource group operations for a given resource group.
         /// </summary>
-        /// <param name="resourceGroup"> The resource group identifier. </param>
+        /// <param name="resourceGroupId"> The resource group identifier. </param>
         /// <returns> The resource group operations. </returns>
-        public ResourceGroupOperations ResourceGroup(ResourceIdentifier resourceGroup)
+        public ResourceGroupOperations GetResourceGroupOperations(ResourceIdentifier resourceGroupId)
         {
-            return new ResourceGroupOperations(ClientOptions, resourceGroup);
-        }
-
-        /// <summary>
-        /// Gets the resource group operations for a given resource group.
-        /// </summary>
-        /// <param name="resourceGroupId"> The Id of the resource group. </param>
-        /// <returns> The resource group operations. </returns>
-        public ResourceGroupOperations ResourceGroup(string resourceGroupId)
-        {
-            return new ResourceGroupOperations(ClientOptions, $"{Id}/resourceGroups/{resourceGroupId}");
+            return new ResourceGroupOperations(ClientOptions, resourceGroupId);
         }
 
         /// <summary>
         /// Gets the resource group container under this subscription
         /// </summary>
         /// <returns> The resource group container. </returns>
-        public ResourceGroupContainer ResourceGroups()
+        public ResourceGroupContainer GetResourceGroupContainer()
         {
             return new ResourceGroupContainer(ClientOptions, this);
         }

--- a/Azure.ResourceManager.Core/SubscriptionOperations.cs
+++ b/Azure.ResourceManager.Core/SubscriptionOperations.cs
@@ -22,6 +22,16 @@ namespace Azure.ResourceManager.Core
         /// Initializes a new instance of the <see cref="SubscriptionOperations"/> class.
         /// </summary>
         /// <param name="options"> The client parameters to use in these operations. </param>
+        /// <param name="subscriptionId"> The Id of the subscription. </param>
+        internal SubscriptionOperations(AzureResourceManagerClientOptions options, string subscriptionId)
+            : base(options, $"/subscriptions/{subscriptionId}")
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubscriptionOperations"/> class.
+        /// </summary>
+        /// <param name="options"> The client parameters to use in these operations. </param>
         /// <param name="id"> The identifier of the subscription. </param>
         internal SubscriptionOperations(AzureResourceManagerClientOptions options, ResourceIdentifier id)
             : base(options, id)

--- a/azure-proto-authorization/Extensions/RoleAssignmentExtensions.cs
+++ b/azure-proto-authorization/Extensions/RoleAssignmentExtensions.cs
@@ -13,7 +13,7 @@ namespace azure_proto_authorization
         /// </summary>
         /// <param name="resource">The resource that is the target of the roel assignemnt</param>
         /// <returns>A <see cref="RoleAssignmentContainer"/> that allows creating and listing RoleAssignments</returns>
-        public static RoleAssignmentContainer RoleAssignments(this ResourceOperationsBase resource)
+        public static RoleAssignmentContainer GetRoleAssignmentContainer(this ResourceOperationsBase resource)
         {
             return new RoleAssignmentContainer(resource);
         }
@@ -24,7 +24,7 @@ namespace azure_proto_authorization
         /// </summary>
         /// <param name="resource">The subscription that is the target of the role assignemnt</param>
         /// <returns>A <see cref="RoleAssignmentContainer"/> that allows creating and listing RoleAssignments</returns>
-        public static RoleAssignmentContainer RoleAssignments(this SubscriptionOperations resource)
+        public static RoleAssignmentContainer GetRoleAssignmentContainer(this SubscriptionOperations resource)
         {
             return new RoleAssignmentContainer(resource);
         }
@@ -36,7 +36,7 @@ namespace azure_proto_authorization
         /// <param name="subscription">The subscription containign the role assignment</param>
         /// <param name="scope">The target of the role assignment</param>
         /// <returns>A <see cref="RoleAssignmentContainer"/> that allows creating and listing RoleAssignments</returns>
-        public static RoleAssignmentContainer RoleAssigmentsAtScope(this SubscriptionOperations subscription, ResourceIdentifier scope)
+        public static RoleAssignmentContainer GetRoleAssigmentContainerAtScope(this SubscriptionOperations subscription, ResourceIdentifier scope)
         {
             return new RoleAssignmentContainer(subscription.ClientOptions, scope);
         }
@@ -48,7 +48,7 @@ namespace azure_proto_authorization
         /// <param name="subscription">The subscription containign the role assignment</param>
         /// <param name="scope">The target of the role assignment</param>
         /// <returns>A <see cref="RoleAssignmentContainer"/> that allows creating and listing RoleAssignments</returns>
-        public static RoleAssignmentContainer RoleAssigmentsAtScope(this SubscriptionOperations subscription, Resource scope)
+        public static RoleAssignmentContainer GetRoleAssigmentContainerAtScope(this SubscriptionOperations subscription, Resource scope)
         {
             return new RoleAssignmentContainer(subscription.ClientOptions, scope.Id);
         }
@@ -60,7 +60,7 @@ namespace azure_proto_authorization
         /// <param name="resource">The resource containing the role assignment</param>
         /// <param name="name">The name of the role assignment</param>
         /// <returns>A <see cref="RoleAssignmentOperations"/> that allows getting and deleting RoleAssignments</returns>
-        public static RoleAssignmentOperations RoleAssignment(this ResourceOperationsBase resource, string name)
+        public static RoleAssignmentOperations GetRoleAssignmentOperations(this ResourceOperationsBase resource, string name)
         {
             return new RoleAssignmentOperations(resource.ClientOptions, $"{resource.Id}/providers/Microsoft.Authorization/roleAssignments/{name}");
         }
@@ -72,7 +72,7 @@ namespace azure_proto_authorization
         /// <param name="resource">The subscription containing the role assignment</param>
         /// <param name="name">The name of the role assignment</param>
         /// <returns>A <see cref="RoleAssignmentOperations"/> that allows getting and deleting RoleAssignments</returns>
-        public static RoleAssignmentOperations RoleAssignment(this SubscriptionOperations resource, string name)
+        public static RoleAssignmentOperations GetRoleAssignmentOperations(this SubscriptionOperations resource, string name)
         {
             return new RoleAssignmentOperations(resource.ClientOptions, $"{resource.Id}/providers/Microsoft.Authorization/roleAssignments/{name}");
         }
@@ -84,7 +84,7 @@ namespace azure_proto_authorization
         /// <param name="resource">The subscription containing the role assignment</param>
         /// <param name="resourceId">The id of the role assignment</param>
         /// <returns>A <see cref="RoleAssignmentOperations"/> that allows getting and deleting RoleAssignments</returns>
-        public static RoleAssignmentOperations RoleAssignmentAtScope(this SubscriptionOperations resource, ResourceIdentifier resourceId)
+        public static RoleAssignmentOperations GetRoleAssignmentOperationsAtScope(this SubscriptionOperations resource, ResourceIdentifier resourceId)
         {
             return new RoleAssignmentOperations(resource.ClientOptions, resourceId);
         }
@@ -96,7 +96,7 @@ namespace azure_proto_authorization
         /// <param name="resource">The subscription containing the role assignment</param>
         /// <param name="role">The object representing the role assignment</param>
         /// <returns>A <see cref="RoleAssignmentOperations"/> that allows getting and deleting RoleAssignments</returns>
-        public static RoleAssignmentOperations RoleAssignmentAtScope(this SubscriptionOperations resource, RoleAssignmentData role)
+        public static RoleAssignmentOperations GetRoleAssignmentOperationsAtScope(this SubscriptionOperations resource, RoleAssignmentData role)
         {
             return new RoleAssignmentOperations(resource.ClientOptions, role);
         }

--- a/azure-proto-compute/Extensions/AzureResourceManagerClientOptionsExtensions.cs
+++ b/azure-proto-compute/Extensions/AzureResourceManagerClientOptionsExtensions.cs
@@ -12,7 +12,7 @@ namespace azure_proto_compute.Extensions
         /// </summary>
         ///<param> The <see  cref="[AzureResourceManagerClientOptions]" /> instance the method will execute against. </param>
         /// <returns> Returns a response with the <see cref="ComputeRestApiVersions"/> operation for this resource. </returns>
-        public static ComputeRestApiVersions ComputeRestVersions(this AzureResourceManagerClientOptions azureResourceManagerClientOptions)
+        public static ComputeRestApiVersions GetComputeRestApiVersions(this AzureResourceManagerClientOptions azureResourceManagerClientOptions)
         {
             return azureResourceManagerClientOptions.GetOverrideObject<ComputeRestApiVersions>(() => new ComputeRestApiVersions()) as ComputeRestApiVersions;
         }

--- a/azure-proto-compute/Extensions/ResourceGroupExtensions.cs
+++ b/azure-proto-compute/Extensions/ResourceGroupExtensions.cs
@@ -8,6 +8,16 @@ namespace azure_proto_compute
     public static class ResourceGroupExtensions
     {
         #region VirtualMachines
+        /// <summary>
+        /// Gets an object representing the operations that can be performed over a specific VirtualMachine.
+        /// </summary>
+        /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
+        /// <param name="vmName"> The name of the VirtualMachine. </param>
+        /// <returns> Returns an object representing the operations that can be performed over a specific <see cref="[VirtualMachine]" />.</returns>
+        public static VirtualMachineOperations GetVirtualMachineOperations(this ResourceGroupOperations resourceGroup, string vmName)
+        {
+            return new VirtualMachineOperations(resourceGroup.ClientOptions, $"{resourceGroup.Id}/providers/Microsoft.Compute/virtualMachines/{vmName}");
+        }
 
         /// <summary>
         /// Gets an object representing the operations that can be performed over a specific VirtualMachine.
@@ -42,6 +52,15 @@ namespace azure_proto_compute
         #endregion
 
         #region AvailabilitySets
+        /// <summary>
+        /// Gets an object representing the operations that can be performed over a specific AvailabilitySet.
+        /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
+        /// <param name="availabilitySetName"> The name of the AvailibilitySet. </param>
+        /// <returns> Returns an object representing the operations that can be performed over a specific <see cref="[AvailabilitySet]" />. </returns>
+        public static AvailabilitySetOperations GetAvailabilitySetOperations(this ResourceGroupOperations resourceGroup, string availabilitySetName)
+        {
+            return new AvailabilitySetOperations(resourceGroup.ClientOptions, $"{resourceGroup.Id}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}");
+        }
 
         /// <summary>
         /// Gets an object representing the operations that can be performed over a specific AvailabilitySet.

--- a/azure-proto-compute/Extensions/ResourceGroupExtensions.cs
+++ b/azure-proto-compute/Extensions/ResourceGroupExtensions.cs
@@ -8,16 +8,6 @@ namespace azure_proto_compute
     public static class ResourceGroupExtensions
     {
         #region VirtualMachines
-        /// <summary>
-        /// Gets an object representing the operations that can be performed over a specific VirtualMachine.
-        /// </summary>
-        /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
-        /// <param name="vmName"> The name of the VirtualMachine. </param>
-        /// <returns> Returns an object representing the operations that can be performed over a specific <see cref="[VirtualMachine]" />.</returns>
-        public static VirtualMachineOperations VirtualMachine(this ResourceGroupOperations resourceGroup, string vmName)
-        {
-            return new VirtualMachineOperations(resourceGroup.ClientOptions, $"{resourceGroup.Id}/providers/Microsoft.Compute/virtualMachines/{vmName}");
-        }
 
         /// <summary>
         /// Gets an object representing the operations that can be performed over a specific VirtualMachine.
@@ -25,20 +15,9 @@ namespace azure_proto_compute
         /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
         /// <param name="vmId"> The identifier of the resource that is the target of operations. </param>
         /// <returns> Returns an object representing the operations that can be performed over a specific <see cref="[VirtualMachine]" />.</returns>
-        public static VirtualMachineOperations VirtualMachine(this ResourceGroupOperations resourceGroup, ResourceIdentifier vmId)
+        public static VirtualMachineOperations GetVirtualMachineOperations(this ResourceGroupOperations resourceGroup, ResourceIdentifier vmId)
         {
             return new VirtualMachineOperations(resourceGroup.ClientOptions, vmId);
-        }
-
-        /// <summary>
-        /// Gets an object representing a VirtualMachine along with the instance operations that can be performed on it.
-        /// </summary>
-        /// <param> The <see cref="[ResourceGroup]" /> instance the method will execute against. </param>
-        /// <param name="vmData"> The <see cref="[VirtualMachineData]" /> of the resource that is the target of operations. </param>
-        /// <returns> Returns a <see cref="[VirtualMachine]" /> object. </returns>
-        public static VirtualMachine VirtualMachine(this ResourceGroup resourceGroup, VirtualMachineData vmData)
-        {
-            return new VirtualMachine(resourceGroup.ClientOptions, vmData);
         }
 
         /// <summary>
@@ -46,7 +25,7 @@ namespace azure_proto_compute
         /// </summary>
         /// <param> The <see cref="[ResourceGroup]" /> instance the method will execute against. </param>
         /// <returns> Returns a <see cref="[VirtualMachineContainer]" /> object. </returns>
-        public static VirtualMachineContainer VirtualMachines(this ResourceGroup resourceGroup)
+        public static VirtualMachineContainer GetVirtualMachineContainer(this ResourceGroup resourceGroup)
         {
             return new VirtualMachineContainer(resourceGroup.ClientOptions, resourceGroup.Data);
         }
@@ -56,22 +35,13 @@ namespace azure_proto_compute
         /// </summary>
         /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
         /// <returns> Returns a <see cref="[VirtualMachineContainer]" /> object. </returns>
-        public static VirtualMachineContainer VirtualMachines(this ResourceGroupOperations resourceGroup)
+        public static VirtualMachineContainer GetVirtualMachineContainer(this ResourceGroupOperations resourceGroup)
         {
             return new VirtualMachineContainer(resourceGroup.ClientOptions, resourceGroup.Id);
         }
         #endregion
 
         #region AvailabilitySets
-        /// <summary>
-        /// Gets an object representing the operations that can be performed over a specific AvailabilitySet.
-        /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
-        /// <param name="availabilitySetName"> The name of the AvailibilitySet. </param>
-        /// <returns> Returns an object representing the operations that can be performed over a specific <see cref="[AvailabilitySet]" />. </returns>
-        public static AvailabilitySetOperations AvailabilitySet(this ResourceGroupOperations resourceGroup, string availabilitySetName)
-        {
-            return new AvailabilitySetOperations(resourceGroup.ClientOptions, $"{resourceGroup.Id}/providers/Microsoft.Compute/availabilitySets/{availabilitySetName}");
-        }
 
         /// <summary>
         /// Gets an object representing the operations that can be performed over a specific AvailabilitySet.
@@ -79,20 +49,9 @@ namespace azure_proto_compute
         /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
         /// <param name="availabilitySetId"> The identifier of the resource that is the target of operations. </param>
         /// <returns> Returns an object representing the operations that can be performed over a specific <see cref="[AvailabilitySet]" />. </returns>
-        public static AvailabilitySetOperations AvailabilitySet(this ResourceGroupOperations resourceGroup, ResourceIdentifier availabilitySetId)
+        public static AvailabilitySetOperations GetAvailabilitySetOperations(this ResourceGroupOperations resourceGroup, ResourceIdentifier availabilitySetId)
         {
             return new AvailabilitySetOperations(resourceGroup.ClientOptions, availabilitySetId);
-        }
-
-        /// <summary>
-        /// Gets an object representing a AvailabilitySet along with the instance operations that can be performed on it.
-        /// </summary>
-        /// <param> The <see cref="[ResourceGroup]" /> instance the method will execute against. </param>
-        /// <param name="availabilitySetData"> The <see cref="[AvailabilitySetData]" /> of the resource that is the target of operations. </param>
-        /// <returns> Returns an <see cref="[AvailabilitySet]" /> object. </returns>
-        public static AvailabilitySet AvailabilitySet(this ResourceGroup resourceGroup, AvailabilitySetData availabilitySetData)
-        {
-            return new AvailabilitySet(resourceGroup.ClientOptions, availabilitySetData);
         }
 
         /// <summary>
@@ -100,7 +59,7 @@ namespace azure_proto_compute
         /// </summary>
         /// <param> The <see cref="[ResourceGroup]" /> instance the method will execute against. </param>
         /// <returns> Returns an <see cref="[AvailabilitySetContainer]" /> object. </returns>
-        public static AvailabilitySetContainer AvailabilitySets(this ResourceGroup resourceGroup)
+        public static AvailabilitySetContainer GetAvailabilitySetContainer(this ResourceGroup resourceGroup)
         {
             return new AvailabilitySetContainer(resourceGroup.ClientOptions, resourceGroup.Data);
         }
@@ -110,7 +69,7 @@ namespace azure_proto_compute
         /// </summary>
         /// <param> The <see cref="[ResourceGroupOperations]" /> instance the method will execute against. </param>
         /// <returns> Returns an <see cref="[AvailabilitySetContainer]" /> object. </returns>
-        public static AvailabilitySetContainer AvailabilitySets(this ResourceGroupOperations resourceGroup)
+        public static AvailabilitySetContainer GetAvailabilitySetContainer(this ResourceGroupOperations resourceGroup)
         {
             return new AvailabilitySetContainer(resourceGroup.ClientOptions, resourceGroup.Id);
         }

--- a/azure-proto-network/Extensions/ResourceGroupExtensions.cs
+++ b/azure-proto-network/Extensions/ResourceGroupExtensions.cs
@@ -12,24 +12,14 @@ namespace azure_proto_network
     {
         #region Virtual Network Operations
 
-        /// <summary>
-        /// Gets a <see cref="VirtualNetwork"/> for a given resource under a <see cref="ResourceGroup"/>. 
-        /// </summary>
-        /// <param name="resourceGroup"> The <see cref="ResourceGroup" /> instance the method will execute against. </param>
-        /// <param name="virtualNetwork"> The <see cref="VirtualNetworkData" /> data model. </param>
-        /// <returns> An instance of <see cref="VirtualNetwork" />. </returns>
-        public static VirtualNetwork VirtualNetwork(this ResourceGroup resourceGroup, VirtualNetworkData virtualNetwork)
-        {
-            return new VirtualNetwork(resourceGroup.ClientOptions, virtualNetwork);
-        }
 
         /// <summary>
         /// Gets a <see cref="VirtualNetworkOperations"/> for a given resource under a <see cref="ResourceGroup"/>. 
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
-        /// <param name="virtualNetwork"> The resource id of <see cref="VirtualNetwork" /> data model. </param>
+        /// <param name="virtualNetwork"> The resource id of <see cref="GetVirtualNetworkOperations" /> data model. </param>
         /// <returns> An instance of <see cref="VirtualNetworkOperations" />. </returns>
-        public static VirtualNetworkOperations VirtualNetwork(this ResourceGroupOperations resourceGroup, string virtualNetwork)
+        public static VirtualNetworkOperations GetVirtualNetworkOperations(this ResourceGroupOperations resourceGroup, string virtualNetwork)
         {
             return new VirtualNetworkOperations(resourceGroup.ClientOptions, new ResourceIdentifier($"{resourceGroup.Id}/providers/Microsoft.Network/virtualNetworks/{virtualNetwork}"));
         }
@@ -39,7 +29,7 @@ namespace azure_proto_network
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroup" /> instance the method will execute against. </param>
         /// <returns> An instance of <see cref="VirtualNetworkContainer" />. </returns>
-        public static VirtualNetworkContainer VirtualNetworks(this ResourceGroup resourceGroup)
+        public static VirtualNetworkContainer GetVirtualNetworkContainer(this ResourceGroup resourceGroup)
         {
             return new VirtualNetworkContainer(resourceGroup.ClientOptions, resourceGroup.Data);
         }
@@ -49,7 +39,7 @@ namespace azure_proto_network
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
         /// <returns> An instance of <see cref="VirtualNetworkContainer" />. </returns>
-        public static VirtualNetworkContainer VirtualNetworks(this ResourceGroupOperations resourceGroup)
+        public static VirtualNetworkContainer GetVirtualNetworkContainer(this ResourceGroupOperations resourceGroup)
         {
             return new VirtualNetworkContainer(resourceGroup.ClientOptions, resourceGroup.Id);
         }
@@ -58,23 +48,12 @@ namespace azure_proto_network
         #region Public IP Address Operations
 
         /// <summary>
-        /// Gets a <see cref="PublicIpAddress"/> under a <see cref="ResourceGroup"/>. 
-        /// </summary>
-        /// <param name="resourceGroup"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
-        /// <param name="publicIpAddress"> The <see cref="PublicIPAddressData" /> data model. </param>
-        /// <returns> An instance of <see cref="PublicIpAddress" />. </returns>
-        public static PublicIpAddress PublicIpAddress(this ResourceGroupOperations resourceGroup, PublicIPAddressData publicIpAddress)
-        {
-            return new PublicIpAddress(resourceGroup.ClientOptions, publicIpAddress);
-        }
-
-        /// <summary>
         /// Gets a <see cref="PublicIpAddressOperations"/> under a <see cref="ResourceGroup"/>. 
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
-        /// <param name="publicIpAddress"> The resource id of <see cref="PublicIpAddress" /> data model. </param>
+        /// <param name="publicIpAddress"> The resource id of <see cref="GetPublicIpAddressOperations" /> data model. </param>
         /// <returns> An instance of <see cref="PublicIpAddressOperations" />. </returns>
-        public static PublicIpAddressOperations PublicIpAddress(this ResourceGroupOperations resourceGroup, string publicIpAddress)
+        public static PublicIpAddressOperations GetPublicIpAddressOperations(this ResourceGroupOperations resourceGroup, string publicIpAddress)
         {
             return new PublicIpAddressOperations(resourceGroup.ClientOptions, new ResourceIdentifier($"{resourceGroup.Id}/providers/Microsoft.Network/publicIpAddresses/{publicIpAddress}"));
         }
@@ -84,7 +63,7 @@ namespace azure_proto_network
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroup" /> instance the method will execute against. </param>
         /// <returns> An instance of <see cref="PublicIpAddressContainer" />. </returns>
-        public static PublicIpAddressContainer PublicIpAddresses(this ResourceGroup resourceGroup)
+        public static PublicIpAddressContainer GetPublicIpAddressContainer(this ResourceGroup resourceGroup)
         {
             return new PublicIpAddressContainer(resourceGroup.ClientOptions, resourceGroup.Data);
         }
@@ -94,7 +73,7 @@ namespace azure_proto_network
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
         /// <returns> An instance of <see cref="PublicIpAddressContainer" />. </returns>
-        public static PublicIpAddressContainer PublicIpAddresses(this ResourceGroupOperations resourceGroup)
+        public static PublicIpAddressContainer GetPublicIpAddresseContainer(this ResourceGroupOperations resourceGroup)
         {
             return new PublicIpAddressContainer(resourceGroup.ClientOptions, resourceGroup.Id);
         }
@@ -103,45 +82,34 @@ namespace azure_proto_network
         #region Network Interface (NIC) operations
 
         /// <summary>
-        /// Gets the operations over a specific <see cref="NetworkInterface>"/>
-        /// </summary>
-        /// <param name="resourceGroup"> The operations over a specific resource group. </param>
-        /// <param name="networkInterface"> The network interface to target for operations. </param>
-        /// <returns> A <see cref="NetworkInterface"/> including the operations that can be peformed on it. </returns>
-        public static NetworkInterface NetworkInterface(this ResourceGroupOperations resourceGroup, NetworkInterfaceData networkInterface)
-        {
-            return new NetworkInterface(resourceGroup.ClientOptions, networkInterface);
-        }
-
-        /// <summary>
-        /// Gets the operations over a specific <see cref="NetworkInterface>"/>
+        /// Gets the operations over a specific <see cref="GetNetworkInterfaceOperations>"/>
         /// </summary>
         /// <param name="resourceGroup"> The operations over a specific resource group. </param>
         /// <param name="networkInterface"> The name of the network interface to target for operations. </param>
-        /// <returns> A <see cref="NetworkInterface"/> including the operations that can be peformed on it. </returns>
-        public static NetworkInterfaceOperations NetworkInterface(this ResourceGroupOperations resourceGroup, string networkInterface)
+        /// <returns> A <see cref="GetNetworkInterfaceOperations"/> including the operations that can be peformed on it. </returns>
+        public static NetworkInterfaceOperations GetNetworkInterfaceOperations(this ResourceGroupOperations resourceGroup, string networkInterface)
         {
             return new NetworkInterfaceOperations(resourceGroup.ClientOptions, new ResourceIdentifier($"{resourceGroup.Id}/providers/Microsoft.Network/networkInterfaces/{networkInterface}"));
         }
 
         /// <summary>
-        /// Gets the operations over the collection of <see cref="NetworkInterface"/> contained in the resource group.
+        /// Gets the operations over the collection of <see cref="GetNetworkInterfaceOperations"/> contained in the resource group.
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroup"/> that contains the network interfaces. </param>
-        /// <returns> A <see cref="NetworkInterfaceContainer"/> representing the collection of <see cref="NetworkInterface"/> 
+        /// <returns> A <see cref="NetworkInterfaceContainer"/> representing the collection of <see cref="GetNetworkInterfaceOperations"/> 
         /// in the resource group. </returns>
-        public static NetworkInterfaceContainer NetworkInterfaces(this ResourceGroup resourceGroup)
+        public static NetworkInterfaceContainer GetNetworkInterfaceContainer(this ResourceGroup resourceGroup)
         {
             return new NetworkInterfaceContainer(resourceGroup.ClientOptions, resourceGroup.Data);
         }
 
         /// <summary>
-        /// Gets the operations over the collection of <see cref="NetworkInterface"/> contained in the resource group.
+        /// Gets the operations over the collection of <see cref="GetNetworkInterfaceOperations"/> contained in the resource group.
         /// </summary>
         /// <param name="resourceGroup"> The name of the <see cref="ResourceGroup"/> that contains the network interfaces. </param>
-        /// <returns> A <see cref="NetworkInterfaceContainer"/> representing the collection of <see cref="NetworkInterface"/> 
+        /// <returns> A <see cref="NetworkInterfaceContainer"/> representing the collection of <see cref="GetNetworkInterfaceOperations"/> 
         /// in the resource group. </returns>
-        public static NetworkInterfaceContainer NetworkInterfaces(this ResourceGroupOperations resourceGroup)
+        public static NetworkInterfaceContainer GetNetworkInterfaceContainer(this ResourceGroupOperations resourceGroup)
         {
             return new NetworkInterfaceContainer(resourceGroup.ClientOptions, resourceGroup.Id);
         }
@@ -150,23 +118,12 @@ namespace azure_proto_network
         #region Network Security Group operations
 
         /// <summary>
-        /// Gets a <see cref="NetworkSecurityGroup"/> under a <see cref="ResourceGroup"/>.
-        /// </summary>
-        /// <param name="resourceGroup"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
-        /// <param name="networkSecurityGroup"> The <see cref="NetworkSecurityGroupData" /> data model. </param>
-        /// <returns> An instance of <see cref="NetworkSecurityGroup" />. </returns>
-        public static NetworkSecurityGroup NetworkSecurityGroup(this ResourceGroupOperations resourceGroup, NetworkSecurityGroupData networkSecurityGroup)
-        {
-            return new NetworkSecurityGroup(resourceGroup.ClientOptions, networkSecurityGroup);
-        }
-
-        /// <summary>
         /// Gets a <see cref="NetworkSecurityGroupOperations"/> under a <see cref="ResourceGroup"/>.
         /// </summary>
         /// <param name="operations"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
-        /// <param name="networkSecurityGroup"> The resource id of <see cref="NetworkSecurityGroup" /> data model. </param>
+        /// <param name="networkSecurityGroup"> The resource id of <see cref="GetNetworkSecurityGroupOperations" /> data model. </param>
         /// <returns> An instance of <see cref="NetworkSecurityGroupOperations" />. </returns>
-        public static NetworkSecurityGroupOperations NetworkSecurityGroup(this ResourceGroupOperations operations, string networkSecurityGroup)
+        public static NetworkSecurityGroupOperations GetNetworkSecurityGroupOperations(this ResourceGroupOperations operations, string networkSecurityGroup)
         {
             return new NetworkSecurityGroupOperations(operations.ClientOptions, new ResourceIdentifier($"{operations.Id}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroup}"));
         }
@@ -176,7 +133,7 @@ namespace azure_proto_network
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroup" /> instance the method will execute against. </param>
         /// <returns> An instance of <see cref="NetworkSecurityGroupContainer" />. </returns>
-        public static NetworkSecurityGroupContainer NetworkSecurityGroups(this ResourceGroup resourceGroup)
+        public static NetworkSecurityGroupContainer GetNetworkSecurityGroupContainer(this ResourceGroup resourceGroup)
         {
             return new NetworkSecurityGroupContainer(resourceGroup.ClientOptions, resourceGroup.Data);
         }
@@ -186,7 +143,7 @@ namespace azure_proto_network
         /// </summary>
         /// <param name="resourceGroup"> The <see cref="ResourceGroupOperations" /> instance the method will execute against. </param>
         /// <returns> An instance of <see cref="NetworkSecurityGroupContainer" />. </returns>
-        public static NetworkSecurityGroupContainer NetworkSecurityGroups(this ResourceGroupOperations resourceGroup)
+        public static NetworkSecurityGroupContainer GetNetworkSecurityGroupContainer(this ResourceGroupOperations resourceGroup)
         {
             return new NetworkSecurityGroupContainer(resourceGroup.ClientOptions, resourceGroup.Id);
         }

--- a/client/Program.cs
+++ b/client/Program.cs
@@ -18,7 +18,7 @@ namespace client
                 foreach (var rgId in Scenario.CleanUp)
                 {
                     ResourceIdentifier id = new ResourceIdentifier(rgId);
-                    var rg = new AzureResourceManagerClient().Subscription(id.Subscription).ResourceGroup(id);
+                    var rg = new AzureResourceManagerClient().GetSubscriptionOperations(id.Subscription).GetResourceGroupOperations(id);
                     Console.WriteLine($"--------Deleting {rg.Id.Name}--------");
                     try
                     {

--- a/client/Scenarios/AddTagToGeneric.cs
+++ b/client/Scenarios/AddTagToGeneric.cs
@@ -11,14 +11,14 @@ namespace client
             var createVm = new CreateSingleVmExample(Context);
             createVm.Execute();
 
-            var rgOp = new AzureResourceManagerClient().ResourceGroup(Context.SubscriptionId, Context.RgName);
-            foreach (var genericOp in rgOp.VirtualMachines().ListByName(Context.VmName))
+            var rgOp = new AzureResourceManagerClient().GetResourceGroupOperations(Context.SubscriptionId, Context.RgName);
+            foreach (var genericOp in rgOp.GetVirtualMachineContainer().ListByName(Context.VmName))
             {
                 Console.WriteLine($"Adding tag to {genericOp.Id}");
                 genericOp.StartAddTag("tagKey", "tagVaue");
             }
 
-            var vmOp = rgOp.VirtualMachine(Context.VmName);
+            var vmOp = rgOp.GetVirtualMachineOperations(Context.VmName);
             Console.WriteLine($"Getting {vmOp.Id}");
             var vm = vmOp.Get().Value;
 

--- a/client/Scenarios/All.cs
+++ b/client/Scenarios/All.cs
@@ -27,7 +27,7 @@ namespace client
                 foreach (var rgId in CleanUp)
                 {
                     ResourceIdentifier id = new ResourceIdentifier(rgId);
-                    var rg = new AzureResourceManagerClient().ResourceGroup(rgId);
+                    var rg = new AzureResourceManagerClient().GetResourceGroupOperations(rgId);
                     Console.WriteLine($"--------Deleting {rg.Id.Name}--------");
                     try
                     {

--- a/client/Scenarios/ClientOverrides.cs
+++ b/client/Scenarios/ClientOverrides.cs
@@ -21,7 +21,7 @@ namespace client
             var client1 = new AzureResourceManagerClient(options1);
             var client2 = new AzureResourceManagerClient(options2);
 
-            foreach (var sub in client1.Subscriptions().List())
+            foreach (var sub in client1.GetSubscriptionContainer().List())
             {
                 var x = sub;
             }

--- a/client/Scenarios/CreateMultipleVms.cs
+++ b/client/Scenarios/CreateMultipleVms.cs
@@ -15,21 +15,21 @@ namespace client
         public override void Execute()
         {
             var client = new AzureResourceManagerClient();
-            var subscription = client.Subscription(Context.SubscriptionId);
+            var subscription = client.GetSubscriptionOperations(Context.SubscriptionId);
 
             // Create Resource Group
             Console.WriteLine($"--------Start create group {Context.RgName}--------");
-            var resourceGroup = subscription.ResourceGroups().Create(Context.RgName, Context.Loc).Value;
+            var resourceGroup = subscription.GetResourceGroupContainer().Create(Context.RgName, Context.Loc).Value;
             CleanUp.Add(resourceGroup.Id);
 
             // Create AvailabilitySet
             Console.WriteLine("--------Start create AvailabilitySet--------");
-            var aset = resourceGroup.AvailabilitySets().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
+            var aset = resourceGroup.GetAvailabilitySetContainer().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
 
             // Create VNet
             Console.WriteLine("--------Start create VNet--------");
             string vnetName = Context.VmName + "_vnet";
-            var vnet = resourceGroup.VirtualNetworks().Construct("10.0.0.0/16").Create(vnetName).Value;
+            var vnet = resourceGroup.GetVirtualNetworkContainer().Construct("10.0.0.0/16").Create(vnetName).Value;
 
             //create subnet
             Console.WriteLine("--------Start create Subnet--------");
@@ -37,7 +37,7 @@ namespace client
 
             //create network security group
             Console.WriteLine("--------Start create NetworkSecurityGroup--------");
-            _ = resourceGroup.NetworkSecurityGroups().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
+            _ = resourceGroup.GetNetworkSecurityGroupContainer().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
 
             CreateVms(resourceGroup, aset, subnet);
         }
@@ -49,17 +49,17 @@ namespace client
             {
                 // Create IP Address
                 Console.WriteLine("--------Start create IP Address--------");
-                var ipAddress = resourceGroup.PublicIpAddresses().Construct().Create($"{Context.VmName}_{i}_ip").Value;
+                var ipAddress = resourceGroup.GetPublicIpAddressContainer().Construct().Create($"{Context.VmName}_{i}_ip").Value;
 
                 // Create Network Interface
                 Console.WriteLine("--------Start create Network Interface--------");
-                var nic = resourceGroup.NetworkInterfaces().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_{i}_nic").Value;
+                var nic = resourceGroup.GetNetworkInterfaceContainer().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_{i}_nic").Value;
 
                 // Create VM
                 string num = i % 2 == 0 ? "-e" : "-o";
                 string name = $"{Context.VmName}{i}{num}";
                 Console.WriteLine("--------Start create VM {0}--------", i);
-                var vmOp = resourceGroup.VirtualMachines().Construct(name, "admin-user", "!@#$%asdfA", nic.Id, aset.Data).StartCreate(name);
+                var vmOp = resourceGroup.GetVirtualMachineContainer().Construct(name, "admin-user", "!@#$%asdfA", nic.Id, aset.Data).StartCreate(name);
                 operations.Add(vmOp);
             }
 

--- a/client/Scenarios/CreateSingleVmExample.cs
+++ b/client/Scenarios/CreateSingleVmExample.cs
@@ -14,21 +14,21 @@ namespace client
         public override void Execute()
         {
             var client = new AzureResourceManagerClient();
-            var subscription = client.Subscription(Context.SubscriptionId);
+            var subscription = client.GetSubscriptionOperations(Context.SubscriptionId);
 
             // Create Resource Group
             Console.WriteLine($"--------Start create group {Context.RgName}--------");
-            var resourceGroup = subscription.ResourceGroups().Create(Context.RgName, Context.Loc).Value;
+            var resourceGroup = subscription.GetResourceGroupContainer().Create(Context.RgName, Context.Loc).Value;
             CleanUp.Add(resourceGroup.Id);
 
             // Create AvailabilitySet
             Console.WriteLine("--------Start create AvailabilitySet--------");
-            var aset = resourceGroup.AvailabilitySets().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
+            var aset = resourceGroup.GetAvailabilitySetContainer().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
 
             // Create VNet
             Console.WriteLine("--------Start create VNet--------");
             string vnetName = Context.VmName + "_vnet";
-            var vnet = resourceGroup.VirtualNetworks().Construct("10.0.0.0/16").Create(vnetName).Value;
+            var vnet = resourceGroup.GetVirtualNetworkContainer().Construct("10.0.0.0/16").Create(vnetName).Value;
 
             //create subnet
             Console.WriteLine("--------Start create Subnet--------");
@@ -36,19 +36,19 @@ namespace client
 
             //create network security group
             Console.WriteLine("--------Start create NetworkSecurityGroup--------");
-            _ = resourceGroup.NetworkSecurityGroups().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
+            _ = resourceGroup.GetNetworkSecurityGroupContainer().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
 
             // Create IP Address
             Console.WriteLine("--------Start create IP Address--------");
-            var ipAddress = resourceGroup.PublicIpAddresses().Construct().Create($"{Context.VmName}_ip").Value;
+            var ipAddress = resourceGroup.GetPublicIpAddressContainer().Construct().Create($"{Context.VmName}_ip").Value;
 
             // Create Network Interface
             Console.WriteLine("--------Start create Network Interface--------");
-            var nic = resourceGroup.NetworkInterfaces().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_nic").Value;
+            var nic = resourceGroup.GetNetworkInterfaceContainer().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_nic").Value;
 
             // Create VM
             Console.WriteLine("--------Start create VM--------");
-            var vm = resourceGroup.VirtualMachines().Construct(Context.VmName, "admin-user", "!@#$%asdfA", nic.Id, aset.Data).Create(Context.VmName).Value;
+            var vm = resourceGroup.GetVirtualMachineContainer().Construct(Context.VmName, "admin-user", "!@#$%asdfA", nic.Id, aset.Data).Create(Context.VmName).Value;
 
             Console.WriteLine("VM ID: " + vm.Id);
             Console.WriteLine("--------Done create VM--------");

--- a/client/Scenarios/DeleteGeneric.cs
+++ b/client/Scenarios/DeleteGeneric.cs
@@ -12,8 +12,8 @@ namespace client
             var createVm = new CreateSingleVmExample(Context);
             createVm.Execute();
 
-            var rgOp = new AzureResourceManagerClient().ResourceGroup(Context.SubscriptionId, Context.RgName);
-            foreach(var genericOp in rgOp.VirtualMachines().ListByName(Context.VmName))
+            var rgOp = new AzureResourceManagerClient().GetResourceGroupOperations(Context.SubscriptionId, Context.RgName);
+            foreach(var genericOp in rgOp.GetVirtualMachineContainer().ListByName(Context.VmName))
             {
                 Console.WriteLine($"Deleting {genericOp.Id}");
                 genericOp.Delete();
@@ -21,7 +21,7 @@ namespace client
 
             try
             {
-                var vmOp = rgOp.VirtualMachine(Context.VmName);
+                var vmOp = rgOp.GetVirtualMachineOperations(Context.VmName);
                 Console.WriteLine($"Trying to get {vmOp.Id}");
                 var response = vmOp.Get();
             }

--- a/client/Scenarios/GenericEntityLoop.cs
+++ b/client/Scenarios/GenericEntityLoop.cs
@@ -11,8 +11,8 @@ namespace client
             var createVm = new CreateSingleVmExample(Context);
             createVm.Execute();
 
-            var rgOp = new AzureResourceManagerClient().ResourceGroup(Context.SubscriptionId, Context.RgName);
-            foreach(var entity in rgOp.VirtualMachines().List())
+            var rgOp = new AzureResourceManagerClient().GetResourceGroupOperations(Context.SubscriptionId, Context.RgName);
+            foreach(var entity in rgOp.GetVirtualMachineContainer().List())
             {
                 Console.WriteLine($"{entity.Id.Name}");
                 entity.StartAddTag("name", "Value");

--- a/client/Scenarios/GetSubscription.cs
+++ b/client/Scenarios/GetSubscription.cs
@@ -10,7 +10,7 @@ namespace client
         {
             var sandboxId = "db1ab6f0-4769-4b27-930e-01e2ef9c123c";
             var expectDisplayName = "Azure SDK sandbox";
-            var subOp = new AzureResourceManagerClient().Subscription(sandboxId);
+            var subOp = new AzureResourceManagerClient().GetSubscriptionOperations(sandboxId);
             var result = subOp.Get();
             Debug.Assert(expectDisplayName == result.Value.Data.DisplayName);
             Console.WriteLine("Passed, got " + result.Value.Data.DisplayName);

--- a/client/Scenarios/ListByNameExpanded.cs
+++ b/client/Scenarios/ListByNameExpanded.cs
@@ -13,63 +13,63 @@ namespace client
             var createMultipleVms = new CreateMultipleVms(Context);
             createMultipleVms.Execute();
 
-            var rg = new AzureResourceManagerClient().ResourceGroup(Context.SubscriptionId, Context.RgName).Get().Value;
-            foreach (var availabilitySet in rg.AvailabilitySets().ListByName(Environment.UserName))
+            var rg = new AzureResourceManagerClient().GetResourceGroupOperations(Context.SubscriptionId, Context.RgName).Get().Value;
+            foreach (var availabilitySet in rg.GetAvailabilitySetContainer().ListByName(Environment.UserName))
             {
                 Console.WriteLine($"--------AvailabilitySet operation id--------: {availabilitySet.Id}");
             }
 
-            foreach (var availabilitySet in rg.AvailabilitySets().ListByNameExpanded(Environment.UserName))
+            foreach (var availabilitySet in rg.GetAvailabilitySetContainer().ListByNameExpanded(Environment.UserName))
             {
                 Console.WriteLine($"--------AvailabilitySet id--------: {availabilitySet.Data.Id}");
             }
 
-            foreach (var vm in rg.VirtualMachines().ListByName(Environment.UserName))
+            foreach (var vm in rg.GetVirtualMachineContainer().ListByName(Environment.UserName))
             {
                 Console.WriteLine($"--------VM operation id--------: {vm.Id}");
             }
 
-            foreach (var vm in rg.VirtualMachines().ListByNameExpanded(Environment.UserName))
+            foreach (var vm in rg.GetVirtualMachineContainer().ListByNameExpanded(Environment.UserName))
             {
                 Console.WriteLine($"--------VM id--------: {vm.Data.Id}");
             }
 
-            foreach (var networkInterface in rg.NetworkInterfaces().ListByName(Environment.UserName))
+            foreach (var networkInterface in rg.GetNetworkInterfaceContainer().ListByName(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkInterface operation id--------: {networkInterface.Id}");
             }
 
-            foreach (var networkInterface in rg.NetworkInterfaces().ListByNameExpanded(Environment.UserName))
+            foreach (var networkInterface in rg.GetNetworkInterfaceContainer().ListByNameExpanded(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkInterface id--------: {networkInterface.Data.Id}");
             }
 
-            foreach (var networkSecurityGroup in rg.NetworkSecurityGroups().ListByName(Environment.UserName))
+            foreach (var networkSecurityGroup in rg.GetNetworkSecurityGroupContainer().ListByName(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkSecurityGroup operation id--------: {networkSecurityGroup.Id}");
             }
 
-            foreach (var networkSecurityGroup in rg.NetworkSecurityGroups().ListByNameExpanded(Environment.UserName))
+            foreach (var networkSecurityGroup in rg.GetNetworkSecurityGroupContainer().ListByNameExpanded(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkSecurityGroup id--------: {networkSecurityGroup.Data.Id}");
             }
 
-            foreach (var publicIpAddress in rg.PublicIpAddresses().ListByName(Environment.UserName))
+            foreach (var publicIpAddress in rg.GetPublicIpAddressContainer().ListByName(Environment.UserName))
             {
                 Console.WriteLine($"--------PublicIpAddress operation id--------: {publicIpAddress.Id}");
             }
 
-            foreach (var publicIpAddress in rg.NetworkSecurityGroups().ListByNameExpanded(Environment.UserName))
+            foreach (var publicIpAddress in rg.GetNetworkSecurityGroupContainer().ListByNameExpanded(Environment.UserName))
             {
                 Console.WriteLine($"--------PublicIpAddress id--------: {publicIpAddress.Data.Id}");
             }
 
-            foreach (var VNet in rg.VirtualNetworks().ListByName(Environment.UserName))
+            foreach (var VNet in rg.GetVirtualNetworkContainer().ListByName(Environment.UserName))
             {
                 Console.WriteLine($"--------VNet operation id--------: {VNet.Id}");
             }
 
-            foreach (var VNet in rg.VirtualNetworks().ListByNameExpanded(Environment.UserName))
+            foreach (var VNet in rg.GetVirtualNetworkContainer().ListByNameExpanded(Environment.UserName))
             {
                 Console.WriteLine($"--------VNet id--------: {VNet.Data.Id}");
             }
@@ -78,62 +78,62 @@ namespace client
 
         private async Task ExecuteAsync(ResourceGroup rg)
         {
-            await foreach (var availabilitySet in rg.AvailabilitySets().ListByNameAsync(Environment.UserName))
+            await foreach (var availabilitySet in rg.GetAvailabilitySetContainer().ListByNameAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------AvailabilitySet operation id--------: {availabilitySet.Id}");
             }
 
-            await foreach (var availabilitySet in rg.AvailabilitySets().ListByNameExpandedAsync(Environment.UserName))
+            await foreach (var availabilitySet in rg.GetAvailabilitySetContainer().ListByNameExpandedAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------AvailabilitySet id--------: {availabilitySet.Data.Id}");
             }
 
-            await foreach (var vm in rg.VirtualMachines().ListByNameAsync(Environment.UserName))
+            await foreach (var vm in rg.GetVirtualMachineContainer().ListByNameAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------VM operation id--------: {vm.Id}");
             }
 
-            await foreach (var vm in rg.VirtualMachines().ListByNameExpandedAsync(Environment.UserName))
+            await foreach (var vm in rg.GetVirtualMachineContainer().ListByNameExpandedAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------VM id--------: {vm.Data.Id}");
             }
 
-            await foreach (var networkInterface in rg.NetworkInterfaces().ListByNameAsync(Environment.UserName))
+            await foreach (var networkInterface in rg.GetNetworkInterfaceContainer().ListByNameAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkInterface operation id--------: {networkInterface.Id}");
             }
 
-            await foreach (var networkInterface in rg.NetworkInterfaces().ListByNameExpandedAsync(Environment.UserName))
+            await foreach (var networkInterface in rg.GetNetworkInterfaceContainer().ListByNameExpandedAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkInterface id--------: {networkInterface.Data.Id}");
             }
 
-            await foreach (var networkSecurityGroup in rg.NetworkSecurityGroups().ListByNameAsync(Environment.UserName))
+            await foreach (var networkSecurityGroup in rg.GetNetworkSecurityGroupContainer().ListByNameAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkSecurityGroup operation id--------: {networkSecurityGroup.Id}");
             }
 
-            await foreach (var networkSecurityGroup in rg.NetworkSecurityGroups().ListByNameExpandedAsync(Environment.UserName))
+            await foreach (var networkSecurityGroup in rg.GetNetworkSecurityGroupContainer().ListByNameExpandedAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------NetworkSecurityGroup id--------: {networkSecurityGroup.Data.Id}");
             }
 
-            await foreach (var publicIpAddress in rg.PublicIpAddresses().ListByNameAsync(Environment.UserName))
+            await foreach (var publicIpAddress in rg.GetPublicIpAddressContainer().ListByNameAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------PublicIpAddress operation id--------: {publicIpAddress.Id}");
             }
 
-            await foreach (var publicIpAddress in rg.NetworkSecurityGroups().ListByNameExpandedAsync(Environment.UserName))
+            await foreach (var publicIpAddress in rg.GetNetworkSecurityGroupContainer().ListByNameExpandedAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------PublicIpAddress id--------: {publicIpAddress.Data.Id}");
             }
 
-            await foreach (var VNet in rg.VirtualNetworks().ListByNameAsync(Environment.UserName))
+            await foreach (var VNet in rg.GetVirtualNetworkContainer().ListByNameAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------VNet operation id--------: {VNet.Id}");
             }
 
-            await foreach (var VNet in rg.VirtualNetworks().ListByNameExpandedAsync(Environment.UserName))
+            await foreach (var VNet in rg.GetVirtualNetworkContainer().ListByNameExpandedAsync(Environment.UserName))
             {
                 Console.WriteLine($"--------VNet id--------: {VNet.Data.Id}");
             }

--- a/client/Scenarios/RoleAssignment.cs
+++ b/client/Scenarios/RoleAssignment.cs
@@ -11,28 +11,28 @@ namespace client
         public override void Execute()
         {
             var client = new AzureResourceManagerClient();
-            var subscription = client.Subscription(Context.SubscriptionId);
+            var subscription = client.GetSubscriptionOperations(Context.SubscriptionId);
 
             // Create Resource Group
             Console.WriteLine($"--------Start create group {Context.RgName}--------");
-            var resourceGroup = subscription.ResourceGroups().Create(Context.RgName, Context.Loc).Value;
+            var resourceGroup = subscription.GetResourceGroupContainer().Create(Context.RgName, Context.Loc).Value;
             CleanUp.Add(resourceGroup.Id);
 
             Console.WriteLine("--------Start create Assignment--------");
             var input = new RoleAssignmentCreateParameters($"/subscriptions/{Context.SubscriptionId}/resourceGroups/{Context.RgName}/providers/Microsoft.Authorization/roleDefinitions/{Context.RoleId}", Context.PrincipalId);
-            var assign = resourceGroup.RoleAssignments().Create(Guid.NewGuid().ToString(), input).Value;
+            var assign = resourceGroup.GetRoleAssignmentContainer().Create(Guid.NewGuid().ToString(), input).Value;
             Console.WriteLine("--------Done create Assignment--------");
 
             assign = assign.Get().Value;
 
             // Create AvailabilitySet
             Console.WriteLine("--------Start create AvailabilitySet--------");
-            var aset = resourceGroup.AvailabilitySets().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
+            var aset = resourceGroup.GetAvailabilitySetContainer().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
 
             // Create VNet
             Console.WriteLine("--------Start create VNet--------");
             string vnetName = Context.VmName + "_vnet";
-            var vnet = resourceGroup.VirtualNetworks().Construct("10.0.0.0/16").Create(vnetName).Value;
+            var vnet = resourceGroup.GetVirtualNetworkContainer().Construct("10.0.0.0/16").Create(vnetName).Value;
 
             //create subnet
             Console.WriteLine("--------Start create Subnet--------");
@@ -40,19 +40,19 @@ namespace client
 
             //create network security group
             Console.WriteLine("--------Start create NetworkSecurityGroup--------");
-            _ = resourceGroup.NetworkSecurityGroups().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
+            _ = resourceGroup.GetNetworkSecurityGroupContainer().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
 
             // Create IP Address
             Console.WriteLine("--------Start create IP Address--------");
-            var ipAddress = resourceGroup.PublicIpAddresses().Construct().Create($"{Context.VmName}_ip").Value;
+            var ipAddress = resourceGroup.GetPublicIpAddressContainer().Construct().Create($"{Context.VmName}_ip").Value;
 
             // Create Network Interface
             Console.WriteLine("--------Start create Network Interface--------");
-            var nic = resourceGroup.NetworkInterfaces().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_nic").Value;
+            var nic = resourceGroup.GetNetworkInterfaceContainer().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_nic").Value;
 
             // Create VM
             Console.WriteLine("--------Start create VM--------");
-            var vm = resourceGroup.VirtualMachines().Construct(Context.VmName, "admin-user", "!@#$%asdfA", nic.Id, aset.Data).Create(Context.VmName).Value;
+            var vm = resourceGroup.GetVirtualMachineContainer().Construct(Context.VmName, "admin-user", "!@#$%asdfA", nic.Id, aset.Data).Create(Context.VmName).Value;
 
             Console.WriteLine("VM ID: " + vm.Id);
             Console.WriteLine("--------Done create VM--------");
@@ -60,7 +60,7 @@ namespace client
 
             Console.WriteLine("--------Start create Assignment--------");
             var input2 = new RoleAssignmentCreateParameters($"{vm.Id}/providers/Microsoft.Authorization/roleDefinitions/{Context.RoleId}", Context.PrincipalId);
-            var assign2 = vm.RoleAssignments().Create(Guid.NewGuid().ToString(), input2).Value;
+            var assign2 = vm.GetRoleAssignmentContainer().Create(Guid.NewGuid().ToString(), input2).Value;
             Console.WriteLine("--------Done create Assignment--------");
 
             assign2 = assign2.Get().Value;

--- a/client/Scenarios/SetTagsOnVm.cs
+++ b/client/Scenarios/SetTagsOnVm.cs
@@ -11,8 +11,8 @@ namespace client
             var createVm = new CreateSingleVmExample(Context);
             createVm.Execute();
 
-            var rgOp = new AzureResourceManagerClient().ResourceGroup(Context.SubscriptionId, Context.RgName);
-            var vmOp = rgOp.VirtualMachine(Context.VmName);
+            var rgOp = new AzureResourceManagerClient().GetResourceGroupOperations(Context.SubscriptionId, Context.RgName);
+            var vmOp = rgOp.GetVirtualMachineOperations(Context.VmName);
 
             var vm = vmOp.Get().Value;
             Console.WriteLine($"Adding tags to {vm.Data.Name}");

--- a/client/Scenarios/ShutdownVmsByLINQ.cs
+++ b/client/Scenarios/ShutdownVmsByLINQ.cs
@@ -13,7 +13,7 @@ namespace client
             createMultipleVms.Execute();
 
             var client = new AzureResourceManagerClient();
-            foreach (var sub in client.Subscriptions().List())
+            foreach (var sub in client.GetSubscriptionContainer().List())
             {
                 var vmList = sub.ListVirtualMachines();
                 foreach (var vm in vmList.Where(armResource => armResource.Data.Name.Contains("-o")))
@@ -25,9 +25,9 @@ namespace client
                 }
             }
 
-            var resourceGroup = new AzureResourceManagerClient().ResourceGroup(Context.SubscriptionId, Context.RgName);
+            var resourceGroup = new AzureResourceManagerClient().GetResourceGroupOperations(Context.SubscriptionId, Context.RgName);
 
-            resourceGroup.VirtualMachines().List().Select(vm =>
+            resourceGroup.GetVirtualMachineContainer().List().Select(vm =>
             {
                 var parts = vm.Id.Name.Split('-');
                 var n = Convert.ToInt32(parts[0].Last());

--- a/client/Scenarios/ShutdownVmsByName.cs
+++ b/client/Scenarios/ShutdownVmsByName.cs
@@ -11,7 +11,7 @@ namespace client
             var createMultipleVms = new CreateMultipleVms(Context);
             createMultipleVms.Execute();
 
-            var sub = new AzureResourceManagerClient().Subscription(Context.SubscriptionId);
+            var sub = new AzureResourceManagerClient().GetSubscriptionOperations(Context.SubscriptionId);
 
             foreach(var armResource in sub.ListVirtualMachinesByName("even"))
             {

--- a/client/Scenarios/ShutdownVmsByNameAcrossResourceGroups.cs
+++ b/client/Scenarios/ShutdownVmsByNameAcrossResourceGroups.cs
@@ -19,7 +19,7 @@ namespace client
                 context = new ScenarioContext();
             }
 
-            var subscription = new AzureResourceManagerClient().Subscription(Context.SubscriptionId);
+            var subscription = new AzureResourceManagerClient().GetSubscriptionOperations(Context.SubscriptionId);
 
             Regex reg = new Regex($"{Context.VmName}.*-e");
             Parallel.ForEach(subscription.ListVirtualMachines(), vm =>

--- a/client/Scenarios/ShutdownVmsByNameAcrossSubscriptions.cs
+++ b/client/Scenarios/ShutdownVmsByNameAcrossSubscriptions.cs
@@ -12,7 +12,7 @@ namespace client
         {
             var client = new AzureResourceManagerClient();
 
-            await foreach (var subscription in client.Subscriptions().ListAsync())
+            await foreach (var subscription in client.GetSubscriptionContainer().ListAsync())
             {
                 await foreach (var armResource in subscription.ListVirtualMachinesByNameAsync("-e"))
                 {
@@ -41,7 +41,7 @@ namespace client
 
 
             var client = new AzureResourceManagerClient();
-            foreach (var sub in client.Subscriptions().List())
+            foreach (var sub in client.GetSubscriptionContainer().List())
             {
                 await foreach (var armResource in sub.ListVirtualMachinesByNameAsync("-e"))
                 {

--- a/client/Scenarios/ShutdownVmsByTag.cs
+++ b/client/Scenarios/ShutdownVmsByTag.cs
@@ -12,11 +12,11 @@ namespace client
             var createMultipleVms = new CreateMultipleVms(Context);
             createMultipleVms.Execute();
 
-            var rg = new AzureResourceManagerClient().ResourceGroup(Context.SubscriptionId, Context.RgName).Get().Value;
+            var rg = new AzureResourceManagerClient().GetResourceGroupOperations(Context.SubscriptionId, Context.RgName).Get().Value;
 
             //set tags on random vms
             Random rand = new Random(Environment.TickCount);
-            foreach (var generic in rg.VirtualMachines().ListByName(Environment.UserName))
+            foreach (var generic in rg.GetVirtualMachineContainer().ListByName(Environment.UserName))
             {
                 var vm = VirtualMachineOperations.FromGeneric(generic);
                 if (rand.NextDouble() > 0.5)
@@ -26,7 +26,7 @@ namespace client
                 }
             }
 
-            var filteredList = rg.VirtualMachines().List().Where(vm =>
+            var filteredList = rg.GetVirtualMachineContainer().List().Where(vm =>
             {
                 string value;
                 return (vm.Data.Tags.TryGetValue("tagkey", out value) && value == "tagvalue");

--- a/client/Scenarios/StartFromVm.cs
+++ b/client/Scenarios/StartFromVm.cs
@@ -18,8 +18,8 @@ namespace client
             Console.WriteLine($"Found VM {vm.Id}");
 
             //retrieve from lowest level inside management package gives ability to walk up and down
-            var rg = client.ResourceGroup(Context.SubscriptionId, Context.RgName);
-            var vm2 = rg.VirtualMachine(Context.VmName).Get().Value.Data;
+            var rg = client.GetResourceGroupOperations(Context.SubscriptionId, Context.RgName);
+            var vm2 = rg.GetVirtualMachineOperations(Context.VmName).Get().Value.Data;
             Console.WriteLine($"Found VM {vm2.Id}");
         }
     }

--- a/client/Scenarios/StartStopVm.cs
+++ b/client/Scenarios/StartStopVm.cs
@@ -12,9 +12,9 @@ namespace client
             createVm.Execute();
 
             var client = new AzureResourceManagerClient();
-            var subscription = client.Subscription(Context.SubscriptionId);
-            var resourceGroup = subscription.ResourceGroup(Context.RgName);
-            var vm = resourceGroup.VirtualMachine(Context.VmName);
+            var subscription = client.GetSubscriptionOperations(Context.SubscriptionId);
+            var resourceGroup = subscription.GetResourceGroupOperations(Context.RgName);
+            var vm = resourceGroup.GetVirtualMachineOperations(Context.VmName);
             Console.WriteLine($"Found VM {Context.VmName}");
             Console.WriteLine("--------Stopping VM--------");
             vm.PowerOff();

--- a/client/Scenarios/VmModelBuilder.cs
+++ b/client/Scenarios/VmModelBuilder.cs
@@ -19,36 +19,36 @@ namespace client
         private Task<VirtualMachine> CreateVmWithBuilderAsync()
         {
             var client = new AzureResourceManagerClient();
-            var subscription = client.Subscription(Context.SubscriptionId);
+            var subscription = client.GetSubscriptionOperations(Context.SubscriptionId);
 
             // Create Resource Group
             Console.WriteLine($"--------Start create group {Context.RgName}--------");
-            var resourceGroup = subscription.ResourceGroups().Create(Context.RgName, Context.Loc).Value;
+            var resourceGroup = subscription.GetResourceGroupContainer().Create(Context.RgName, Context.Loc).Value;
 
             // Create AvailabilitySet
             Console.WriteLine("--------Start create AvailabilitySet--------");
-            var aset = resourceGroup.AvailabilitySets().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
+            var aset = resourceGroup.GetAvailabilitySetContainer().Construct("Aligned").Create(Context.VmName + "_aSet").Value;
 
             // Create VNet
             Console.WriteLine("--------Start create VNet--------");
             string vnetName = Context.VmName + "_vnet";
-            var vnet = resourceGroup.VirtualNetworks().Construct("10.0.0.0/16").Create(vnetName).Value;
+            var vnet = resourceGroup.GetVirtualNetworkContainer().Construct("10.0.0.0/16").Create(vnetName).Value;
 
             //create subnet
             Console.WriteLine("--------Start create Subnet--------");
-            var nsg = resourceGroup.NetworkSecurityGroups().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
+            var nsg = resourceGroup.GetNetworkSecurityGroupContainer().Construct(Context.NsgName, 80).Create(Context.NsgName).Value;
             var subnet = vnet.Subnets().Construct(Context.SubnetName, "10.0.0.0/24").Create(Context.SubnetName).Value;
 
             // Create IP Address
             Console.WriteLine("--------Start create IP Address--------");
-            var ipAddress = resourceGroup.PublicIpAddresses().Construct().Create($"{Context.VmName}_ip").Value;
+            var ipAddress = resourceGroup.GetPublicIpAddressContainer().Construct().Create($"{Context.VmName}_ip").Value;
 
             // Create Network Interface
             Console.WriteLine("--------Start create Network Interface--------");
-            var nic = resourceGroup.NetworkInterfaces().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_nic").Value;
+            var nic = resourceGroup.GetNetworkInterfaceContainer().Construct(ipAddress.Data, subnet.Id).Create($"{Context.VmName}_nic").Value;
 
             // Options: required parameters on in the constructor
-            var vm = resourceGroup.VirtualMachines().Construct(Context.VmName, Context.Loc)
+            var vm = resourceGroup.GetVirtualMachineContainer().Construct(Context.VmName, Context.Loc)
                 .UseWindowsImage("admin-user", "!@#$%asdfA")
                 .RequiredNetworkInterface(nic.Id)
                 .RequiredAvalabilitySet(aset.Id)


### PR DESCRIPTION
In some cases it might seem like we should use properties but
given our desire to break dependencies we cannot use properties
because we have to use extension methods which don't support properties.

On top of that we should probably avoid properties as well because
these are more then simple data field accesses. They always construct
a new wrapper object that gets returned and based on some of the
standard guidelines we should use methods

See https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ms229054(v=vs.100)?redirectedfrom=MSDN)
"The operation returns a copy of an internal state (this does not include copies of value type objects returned on the stack)."

For those reasons we should use method for both the instance and extension methods
and so it now comes down to how we name these methods.

Currently we have methods that look like:

Subscription() -> return new SubscriptionOperations
Subscriptions() -> returns new SubscriptionContainer
ResourceGroup() -> return new ResourceGroupOperations
ResourceGroups() -> return new ResourceGroupContainer
VirtualMachine() -> returns new VirtualMachineOperations or VirtualMachine
VirtualMachines() -> returns new VirtualMachineContainer
AvailabilitySet() -> return new AvailabilitySetOperations or AvailabilitySet
AvailabilitySets() -> return new AvailabilitySetContainer

Proposal for method name changes:

Based on naming guidelines (https://docs.microsoft.com/en-us/previous-versions/dotnet/netframework-4.0/ms229012(v=vs.100)#names-of-methods)
for methods we shoudl use a verb describing wht the method action is doing. So in our
cases we are "Getting" stuff so the suggestion is to prefix the methods with "Get".

On top of that it isn't very clear of what object we are getting in different contexts so
we the second part of the proposal is to name the method after the type that will be
returned.

GetSubscriptionOperations() -> return new SubscriptionOperations
GetSubscriptionContainer() -> returns new SubscriptionContainer
GetResourceGroupOperations() -> return new ResourceGroupOperations
GetResourceGroupContainer() -> return new ResourceGroupContainer
GetVirtualMachineOperations() -> returns new VirtualMachineOperations
GetVirtualMachine() -> returns new VirtualMachine
GetVirtualMachineContainer() -> returns new VirtualMachineContainer
GetAvailabilitySetOperations() -> return new AvailabilitySetOperations
GetAvailabilitySet() -> return new AvailabilitySet
GetAvailabilitySetContainer() -> return new AvailabilitySetContainer

This a very basic design that makes it clear what you are getting and also
gives people an indication that they might want to store the value if they
plan to make many requests on the returned object. The names might be a little
long but the pattern of the simple mapping between the name and the what you are
expecting the method to do very clear.